### PR TITLE
DBC22-344: Added camera list page and component

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
     tty: true
     ports:
       - "3000:3000"
+    volumes:
+      - ./src/frontend:/app
+      # One-way volume to use node_modules from inside image
+      - /app/node_modules
     depends_on:
       - django
     command: npm start

--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -1,18 +1,20 @@
-import React from 'react'
+import React from "react";
 
-import { Route, Routes } from 'react-router-dom';
-import '@bcgov/bc-sans/css/BCSans.css';
-import './App.scss';
-import Header from './Header.js';
-import MapPage from './pages/MapPage';
-import StylesPage from './pages/StylesPage';
+import { Route, Routes } from "react-router-dom";
+import "@bcgov/bc-sans/css/BCSans.css";
+import "./App.scss";
+import Header from "./Header.js";
+import MapPage from "./pages/MapPage";
+import StylesPage from "./pages/StylesPage";
+import CamerasPage from "./pages/CamerasPage";
 
 function App() {
   return (
     <div className="App">
       <Header />
       <Routes>
-        <Route path="/" element={<MapPage />}/>
+        <Route path="/" element={<MapPage />} />
+        <Route path="/cameraspage" element={<CamerasPage />} />
         <Route path="/stylespage" element={<StylesPage />} />
       </Routes>
     </div>

--- a/src/frontend/src/Components/Map.js
+++ b/src/frontend/src/Components/Map.js
@@ -24,8 +24,6 @@ import { applyStyle } from "ol-mapbox-style";
 import Advisory from "./Advisory.js";
 import Layers from "./Layers.js";
 import Routes from "./Routes.js";
-import events from "./data/events.js";
-import webcams from "./data/webcams.js";
 import { getEvents } from "./data/events.js";
 import { getWebcams } from "./data/webcams.js";
 import { getAdvisories } from "./data/advisories.js";
@@ -161,8 +159,8 @@ export default function MapWrapper() {
     mapRef.current.addOverlay(popup);
 
     mapRef.current.once("loadend", async () => {
-      const campoints = webcams;
-      const evpoints = events;
+      const campoints = await getWebcams();
+      const evpoints = await getEvents();
       layers.current["webcamsLayer"] = new VectorLayer({
         classname: "webcams",
         visible: true,

--- a/src/frontend/src/Components/cameras/CameraList.js
+++ b/src/frontend/src/Components/cameras/CameraList.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState, useRef } from "react";
+import { getWebcams } from "../data/webcams";
+
+export default function CameraList({ cameras }) {
+  const [webcams, setWebcams] = useState({});
+  const groupedCameras = {};
+  const fetched = useRef();
+
+  useEffect(() => {
+    if (fetched.current) return;
+
+    async function getCameras() {
+      const retrievedCameras = await getWebcams();
+      retrievedCameras.forEach((camera) => {
+        const highway = camera.properties.highway;
+        if (groupedCameras[highway]) {
+          groupedCameras[highway].push(camera);
+        } else {
+          groupedCameras[highway] = [camera];
+        }
+      });
+
+      setWebcams(groupedCameras);
+      fetched.current = true;
+    }
+    if (!webcams.length) {
+      getCameras();
+    }
+  }, []);
+  return (
+    <div>
+      <div>search bar goes here</div>
+      {Object.entries(webcams).map(([highway, cameras]) => (
+        <div key={highway}>
+          <h2>{highway}</h2>
+          <ul>
+            {cameras.map((camera, id) => (
+              <li key={id}>
+                <img src={camera.properties.url} width="300" />
+                {camera.properties.name},{camera.properties.caption}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/frontend/src/Components/data/events.js
+++ b/src/frontend/src/Components/data/events.js
@@ -1,172 +1,87 @@
-import { point } from '@turf/helpers';
+import { point } from "@turf/helpers";
 
 export async function getEvents() {
-  return fetch('http://localhost:8000/api/events/', {
+  return fetch("http://localhost:8000/api/events/", {
     headers: {
-      'Content-Type': 'application/json'
-    }
-  }).then((response) => response.json())
-    .then((data) => (
-      data.events.map((event) => {
-        let lat, lng;
-        if (event.geography.type === 'Point') {
-          lng = event.geography.coordinates[0];
-          lat = event.geography.coordinates[1];
-        } else {
-          [lng, lat] = event.geography.coordinates[0];
-        }
-
-        try {
-          return point([lng, lat], event, { id: event.id });
-        } catch (e) { console.log(e); console.log(event); }
-      })
-    ))
+      "Content-Type": "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => mapEventsData(data.events))
     .catch((error) => {
-      console.log(error);
+      return mapEventsData(eventsDefault);
     });
 }
 
+const mapEventsData = (events) => {
+  const featureObject = events.map((event) => {
+    let lat, lng;
+    if (event.geography.type === "Point") {
+      lng = event.geography.coordinates[0];
+      lat = event.geography.coordinates[1];
+    } else {
+      [lng, lat] = event.geography.coordinates[0];
+    }
+    return point([lng, lat], event, { id: event.id });
+  });
+  return featureObject;
+};
 
-export default [
+const eventsDefault = [
   {
-    "url": "/events/drivebc.ca/153307",
-    "id": "drivebc.ca/153307",
-    "jurisdiction_url": "/jurisdiction",
-    "headline": "Limited Visibility with Heavy Snowfall",
-    "status": "ACTIVE",
-    "description": "Closed at Border of British Columbia and Yukon because of Bridge Wash Out. Updated on Fri Jan 3 at 9:34 am PST. (ID# 153307) (Data by www.DriveBC.ca).",
-    "+ivr_message": "Atlin Highway, Southbound. at Border of British Columbia and Yukon. The road is closed, because of a bridge wash out. Last updated on Friday January 3 at 9:34 am.",
-    "schedule": {
-      "intervals": [
-        "2014-01-03T07:42/",
-      ]
-    },
-    "event_type": "INCIDENT",
-    "event_subtypes": [
-      "HAZARD"
-    ],
-    "updated": "2014-01-03T07:54:35-07:00",
-    "created": "2014-01-03T07:42:22-07:00",
-    "severity": "MAJOR",
-    "geography": {
-      "type": "Point",
-      "coordinates": [
-        [
-          -133.794711,
-          60.000275
-        ],
-      ]
-    },
-    "roads": [
+    jurisdiction_url: "https://tst-api.open511.gov.bc.ca/jurisdiction",
+    url: "https://tst-api.open511.gov.bc.ca/events/drivebc.ca/DBC-3105",
+    id: "drivebc.ca/DBC-3105",
+    headline: "INCIDENT",
+    status: "ACTIVE",
+    created: "2018-11-09T15:36:28-08:00",
+    updated: "2023-05-05T09:45:59-07:00",
+    description:
+      "Highway 1 (on Vancouver Island). Road is CLOSED due to a collision between West Shore Pky and Finlayson Arm Rd (Langford). Expect Major delays due to congestion. Speed limit 60 km/h. TEST EVENT. Last updated Fri May 5 at 9:45 AM PDT. (DBC-3105)",
+    "+ivr_message":
+      "Highway 1 (on Vancouver Island). Road is CLOSED due to a collision between West Shore Pky and Finlayson Arm Rd (Langford). Expect Major delays due to congestion. Speed limit 60 kilometers per hour. Last updated Friday, May 5 at 9:45 AM.",
+    "+linear_reference_km": 18.32,
+    schedule: { intervals: ["2023-05-05T16:45/"] },
+    event_type: "INCIDENT",
+    event_subtypes: ["HAZARD"],
+    severity: "MINOR",
+    geography: { type: "Point", coordinates: [-123.53782, 48.45787] },
+    roads: [{ name: "Highway 1", from: "West Shore Pky", direction: "NONE" }],
+    areas: [
       {
-        "direction": "BOTH",
-        "from": "Border of British Columbia and Yukon",
-        "name": "Atlin Highway",
-        "to": "",
-        "state": "CLOSED",
-        "+delay": ""
+        url: "http://www.geonames.org/8630140",
+        name: "Vancouver Island District",
+        id: "drivebc.ca/2",
       },
     ],
-    "areas": [
-      {
-        "url": "http://www.geonames.org/8630133",
-        "name": "Bulkley Stikine District",
-        "id": "drivebc.ca/10"
-      },
-    ]
   },
   {
-    "url": "/events/drivebc.ca/153307",
-    "id": "drivebc.ca/153307",
-    "jurisdiction_url": "/jurisdiction",
-    "headline": "Limited Visibility with Heavy Snowfall",
-    "status": "ACTIVE",
-    "description": "Closed at Border of British Columbia and Yukon because of Bridge Wash Out. Updated on Fri Jan 3 at 9:34 am PST. (ID# 153307) (Data by www.DriveBC.ca).",
-    "+ivr_message": "Atlin Highway, Southbound. at Border of British Columbia and Yukon. The road is closed, because of a bridge wash out. Last updated on Friday January 3 at 9:34 am.",
-    "schedule": {
-      "intervals": [
-        "2014-01-03T07:42/",
-      ]
-    },
-    "event_type": "INCIDENT",
-    "event_subtypes": [
-      "HAZARD"
-    ],
-    "updated": "2014-01-03T07:54:35-07:00",
-    "created": "2014-01-03T07:42:22-07:00",
-    "severity": "MAJOR",
-    "geography": {
-      "type": "Point",
-      "coordinates": [
-        [
-          -123.144711,
-          49.200275
-        ],
-      ]
-    },
-    "roads": [
+    jurisdiction_url: "https://tst-api.open511.gov.bc.ca/jurisdiction",
+    url: "https://tst-api.open511.gov.bc.ca/events/drivebc.ca/DBC-3009",
+    id: "drivebc.ca/DBC-3009",
+    headline: "CONSTRUCTION",
+    status: "ACTIVE",
+    created: "2018-11-07T19:39:50-08:00",
+    updated: "2022-12-02T09:20:52-08:00",
+    description:
+      "Highway 97. Line painting between Stoner Pit Rd and Chamulak Rd (21 km south of Pineview). Green test 2. Last updated Fri Dec 2 at 9:20 AM PST. (DBC-3009)",
+    "+ivr_message":
+      "Highway 97. Line painting between Stoner Pit Rd and Chamulak Rd (21 km south of Pineview). Last updated Friday, December 2 at 9:20 AM.",
+    "+linear_reference_km": 675.86,
+    schedule: { intervals: ["2022-12-02T17:20/"] },
+    event_type: "CONSTRUCTION",
+    event_subtypes: ["ROAD_MAINTENANCE"],
+    severity: "MINOR",
+    geography: { type: "Point", coordinates: [-122.663606, 53.623426] },
+    roads: [{ name: "Highway 97", from: "Stoner Pit Rd", direction: "NONE" }],
+    areas: [
       {
-        "direction": "BOTH",
-        "from": "Border of British Columbia and Yukon",
-        "name": "Atlin Highway",
-        "to": "",
-        "state": "CLOSED",
-        "+delay": ""
+        url: "http://www.geonames.org/8630131",
+        name: "Fort George District",
+        id: "drivebc.ca/9",
       },
     ],
-    "areas": [
-      {
-        "url": "http://www.geonames.org/8630133",
-        "name": "Bulkley Stikine District",
-        "id": "drivebc.ca/10"
-      },
-    ]
-  },
-  {
-    "url": "/events/drivebc.ca/153307",
-    "id": "drivebc.ca/153307",
-    "jurisdiction_url": "/jurisdiction",
-    "headline": "Limited Visibility with Heavy Snowfall",
-    "status": "ACTIVE",
-    "description": "Closed at Border of British Columbia and Yukon because of Bridge Wash Out. Updated on Fri Jan 3 at 9:34 am PST. (ID# 153307) (Data by www.DriveBC.ca).",
-    "+ivr_message": "Atlin Highway, Southbound. at Border of British Columbia and Yukon. The road is closed, because of a bridge wash out. Last updated on Friday January 3 at 9:34 am.",
-    "schedule": {
-      "intervals": [
-        "2014-01-03T07:42/",
-      ]
-    },
-    "event_type": "INCIDENT",
-    "event_subtypes": [
-      "HAZARD"
-    ],
-    "updated": "2014-01-03T07:54:35-07:00",
-    "created": "2014-01-03T07:42:22-07:00",
-    "severity": "MAJOR",
-    "geography": {
-      "type": "Point",
-      "coordinates": [
-        [
-          -124.794711,
-          49.000275
-        ],
-      ]
-    },
-    "roads": [
-      {
-        "direction": "BOTH",
-        "from": "Border of British Columbia and Yukon",
-        "name": "Atlin Highway",
-        "to": "",
-        "state": "CLOSED",
-        "+delay": ""
-      },
-    ],
-    "areas": [
-      {
-        "url": "http://www.geonames.org/8630133",
-        "name": "Bulkley Stikine District",
-        "id": "drivebc.ca/10"
-      },
-    ]
   },
 ];
+
+export default eventsDefault;

--- a/src/frontend/src/Components/data/webcams.js
+++ b/src/frontend/src/Components/data/webcams.js
@@ -7,11 +7,20 @@ export async function getWebcams() {
     }
   }).then((response) => response.json())
     .then((data) => (
-      data.webcams.map((webcam) => (
+        mapWebcamData(data.webcams)
+    ))
+    .catch((error) => {
+        return mapWebcamData(webcamsDefault)
+    });
+}
+
+const mapWebcamData = (webcams) => {
+    return webcams.map((webcam) => (
         point([webcam.location.longitude, webcam.location.latitude], {
           url: webcam.links.currentImage,
           id: webcam.id,
           name: webcam.camName,
+          highway: webcam.highway.locationDescription,
           caption: webcam.caption,
           coords: {
             lng: webcam.location.longitude,
@@ -19,14 +28,9 @@ export async function getWebcams() {
           },
         }, { id: webcam.id })
       ))
-    ))
-    .catch((error) => {
-        console.log(error);
-    });
 }
 
-export default [
-    {
+const webcamsDefault = [{
         "links": {
             "self": "https://tst-images.drivebc.ca/webcam/api/v1/webcams/2",
             "imageSource": "https://tst-images.drivebc.ca/webcam/api/v1/webcams/2/imageSource",
@@ -2631,3 +2635,5 @@ export default [
         }
     }
 ];
+
+export default webcamsDefault;

--- a/src/frontend/src/Header.js
+++ b/src/frontend/src/Header.js
@@ -30,6 +30,9 @@ export default function Header() {
 						<LinkContainer to="/StylesPage">
 							<Nav.Link>Styleguide</Nav.Link>
 						</LinkContainer>
+						<LinkContainer to="/CamerasPage">
+							<Nav.Link>Cameras</Nav.Link>
+						</LinkContainer>
 					</Nav>
 					</Navbar.Collapse>
 				</Container>

--- a/src/frontend/src/pages/CamerasPage.js
+++ b/src/frontend/src/pages/CamerasPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Container from 'react-bootstrap/Container';
+import CameraList from '../Components/cameras/CameraList'
+
+export default function MapPage() {
+  return (
+    <div>
+    <Container>
+      <CameraList></CameraList>
+      </Container>
+      </div>
+  );
+}


### PR DESCRIPTION
Added React hot reloading volumes to Docker-Compose as a side addition. Right now, the camera entries load twice on refresh due to the Strict Mode wrapper around our React app, which means there may be a better way to structure our loading function or a clean-up function we may implement, I am open to suggestions.