### PR TITLE
DBC22-716: Hide camera location for non preview pages

### DIFF
--- a/src/frontend/src/Components/Map.js
+++ b/src/frontend/src/Components/Map.js
@@ -506,14 +506,16 @@ export default function MapWrapper({
         </Button>
       )}
 
-      <Button
-        className="map-btn cam-location"
-        variant="outline-primary"
-        onClick={handleRecenter}
-      >
-        <FontAwesomeIcon icon={faLocationCrosshairs} />
-        Camera location
-      </Button>
+      {isPreview && (
+          <Button
+          className="map-btn cam-location"
+          variant="outline-primary"
+          onClick={handleRecenter}
+        >
+          <FontAwesomeIcon icon={faLocationCrosshairs} />
+          Camera location
+        </Button>
+      )}
 
       <Button
         className="map-btn zoom-in"


### PR DESCRIPTION
This PR is attempting to hide "Camera Location" button from the map page, except for camera details page.