### PR TITLE
DBC22-931: Removed overriding openlayer dynamic styles for mobile layout

### DIFF
--- a/src/frontend/src/Components/Map.js
+++ b/src/frontend/src/Components/Map.js
@@ -131,6 +131,11 @@ export default function MapWrapper({
       stopEvent: false, // Allow interactions with the overlay content
     });
 
+    const overlayElement = markerOverlay.getElement();
+    if (overlayElement) {
+      overlayElement.parentElement.classList.remove('ol-overlay-container');
+    }
+
     mapRef.current.on('moveend', function (event) {
       const newZoom = mapRef.current.getView().getZoom();
       // Calculate new marker size based on the zoom level

--- a/src/frontend/src/Components/Map.js
+++ b/src/frontend/src/Components/Map.js
@@ -131,11 +131,6 @@ export default function MapWrapper({
       stopEvent: false, // Allow interactions with the overlay content
     });
 
-    const overlayElement = markerOverlay.getElement();
-    if (overlayElement) {
-      overlayElement.parentElement.classList.remove('ol-overlay-container');
-    }
-
     mapRef.current.on('moveend', function (event) {
       const newZoom = mapRef.current.getView().getZoom();
       // Calculate new marker size based on the zoom level

--- a/src/frontend/src/Components/Map.scss
+++ b/src/frontend/src/Components/Map.scss
@@ -20,9 +20,8 @@
       height: calc(100vh - 58px);
     }
 
-    .ol-overlay-container {
-
-      //overriding openlayers dynamic styles for mobile layout
+    .ol-overlay-container:not(:has(> img)) {
+      //overriding openlayers dynamic styles for mobile layout except for having img as a direct child
       @media (max-width: 575px) {
           position: fixed !important;
           bottom: 0 !important;
@@ -381,9 +380,9 @@
   }
 
   .advisories-accordion {
-    position: absolute;
-    top: 2rem;
-    left: 50%;
+    top: 3rem;
+    left: 65%;
+    position: fixed;
     transform: translateX(-50%);
   }
 }

--- a/src/frontend/src/Components/Map.scss
+++ b/src/frontend/src/Components/Map.scss
@@ -21,6 +21,14 @@
     }
 
     .ol-overlay-container {
+
+      //overriding openlayers dynamic styles for mobile layout
+      @media (max-width: 575px) {
+          position: fixed !important;
+          bottom: 0 !important;
+          transform: none !important;
+        }
+
       .ol-popup {
         width: 100vw;
         height: 100%;
@@ -28,7 +36,6 @@
         box-shadow: 0px 1.600000023841858px 3.5999999046325684px 0px rgba(0, 0, 0, 0.13), 0px 0.30000001192092896px 0.8999999761581421px 0px rgba(0, 0, 0, 0.10);
         border-radius: 4px;
         cursor: pointer;
-        margin-bottom: 200px;
 
          @media (min-width: 576px) {
            width: 560px;
@@ -37,6 +44,7 @@
            top: 12px;
            left: 50%;
            transform: translate(-50%, 0);
+           margin-bottom: 200px;
          }
 
         &-content {

--- a/src/frontend/src/Components/Map.scss
+++ b/src/frontend/src/Components/Map.scss
@@ -21,14 +21,6 @@
     }
 
     .ol-overlay-container {
-      //overriding openlayers dynamic styles for mobile layout
-      @media (max-width: 575px) {
-        position: fixed !important;
-        bottom: 0 !important;
-        transform: none !important;
-
-      }
-
       .ol-popup {
         width: 100vw;
         height: 100%;


### PR DESCRIPTION
Removed mobile layout style settings for overriding openlayer dynamic style. These block has no effect on the mobile layout but impacts the my location pin point displaying.