### PR TITLE
Feature/dbc22 1094

### DIFF
--- a/.github/workflows/image-caching.yml
+++ b/.github/workflows/image-caching.yml
@@ -1,0 +1,36 @@
+#To handle a scenario where you may run two instances in one OpenShift namespace
+#we require a CACHING_IMAGE_NAME environment variable set in GitHub for each environment
+name: Build & Deploy Image Caching Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build & Deploy Docker images
+    environment:
+      name: ${{ inputs.environment }}
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v3
+      
+    - name: build image caching
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ vars.CACHING_IMAGE_NAME }}
+        tags: latest ${{ github.sha }}
+        labels: |
+          app=drivebc
+        containerfiles: ./compose/caching/Dockerfile
+    - name: push to registry
+      uses: redhat-actions/push-to-registry@v2.7
+      with:
+        image: ${{ vars.CACHING_IMAGE_NAME }}
+        registry: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.BUILDER_USERNAME }}
+        password: ${{ secrets.BUILDER_TOKEN }}

--- a/compose/caching/Dockerfile
+++ b/compose/caching/Dockerfile
@@ -5,14 +5,9 @@ FROM nginx:stable
 #Copy the template file to the nginx folder as well for testing
 COPY ./src/caching/nginx.conf.template /etc/nginx/
 
-COPY ./src/caching/index.html /usr/share/nginx/html
-COPY ./src/caching/nocachetest.html /usr/share/nginx/html
-
 RUN chmod -R 777 /var/cache/nginx
 RUN chmod -R 777 /var/log/nginx
 RUN chmod -R 775 /etc/nginx
-#temp run commands as I test updating a file. Won't be needed once I get rid of index file.
-RUN chmod -R 777 /usr/share/nginx/html
 
 
 CMD /usr/sbin/nginx -g 'daemon off;'

--- a/compose/caching/Dockerfile
+++ b/compose/caching/Dockerfile
@@ -1,0 +1,23 @@
+FROM nginx:stable
+
+
+#COPY ./src/caching/nginx.conf /etc/nginx/nginx.conf
+#Copy the template file to the nginx folder as well for testing
+COPY ./src/caching/nginx.conf.template /etc/nginx/
+
+COPY ./src/caching/index.html /usr/share/nginx/html
+COPY ./src/caching/nocachetest.html /usr/share/nginx/html
+
+RUN chmod -R 777 /var/cache/nginx
+RUN chmod -R 777 /var/log/nginx
+RUN chmod -R 775 /etc/nginx
+#temp run commands as I test updating a file. Won't be needed once I get rid of index file.
+RUN chmod -R 777 /usr/share/nginx/html
+
+
+CMD /usr/sbin/nginx -g 'daemon off;'
+
+COPY ./compose/caching/entrypoint /
+RUN sed -i 's/\r$//g' /entrypoint && chmod +x /entrypoint
+
+ENTRYPOINT ["/entrypoint"]

--- a/compose/caching/entrypoint
+++ b/compose/caching/entrypoint
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Updating the proxy_pass in the nginx config based on the DRIVEBC_IMAGE_API_BASE_URL variable in the django configmap"
+
+# Display the value
+echo "The value of DRIVEBC_IMAGE_API_BASE_URL in the configmap is" ${DRIVEBC_IMAGE_API_BASE_URL}
+
+#This will remove the trailing / if one exists as it will break the nginx.conf file
+DRIVEBC_IMAGE_API_BASE_URL=${DRIVEBC_IMAGE_API_BASE_URL%/}
+
+#Replace the $DRIVEBC_IMAGE_API_BASE_URL variables in the conf file.
+envsubst "\${DRIVEBC_IMAGE_API_BASE_URL}" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+
+exec "$@"

--- a/src/caching/README.md
+++ b/src/caching/README.md
@@ -1,0 +1,20 @@
+# DriveBC Image Caching
+
+## Background
+The caching mechanism is a very simple nginx instance that has proxy caching setup. It is set to cache both the webcam and ReplayTheDay folders from the DriveBC API server that is set from the django configmap DRIVEBC_IMAGE_API_BASE_URL field. 
+
+
+## Testing 
+
+To use test the cache you simply need to:
+- Ensure you have the correct DRIVEBC_IMAGE_API_BASE_URL set
+    - If you are having issues, you can view the logs as this is set using the entrypoint file during pod startup
+- In OpenShift you would go to Networking -> Routes to find the URL for the Service
+    - NOTE: All the OpenShift configuration is stored in a separate Helm Chart and not part of this image
+- You can now validate the proxy & caching works by appending something like`/webcam/api/v1/webcams/2/imageDisplay` to the URL
+- You should now see an image that got proxied from the source
+- To see if it was a HIT, MISS or STALE image from the cache you can go into DevTools, Network and Refresh. the X-Proxy-Cache should show you the status.
+
+## Deployment Workflow
+
+We have one workflow that can be pointed at any environment to keep it simple for now. Each environment in GitHub will require a CACHING_IMAGE_NAME variable set so that we can handle multiple instances running in one OpenShift namespace.

--- a/src/caching/nginx.conf.template
+++ b/src/caching/nginx.conf.template
@@ -1,0 +1,87 @@
+
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    client_body_temp_path /tmp/client_body_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /dev/null;
+    #may want to look at setting up some cache logging to see what % of files are stale etc
+    
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+    proxy_cache_path /var/cache/nginx keys_zone=images_cache:10m;
+    #gzip  on;
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+        index index.html index.htm;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        # to get index.html page from my source instead of the images.drivebc.ca site
+        location / {
+          index  index.html;
+          try_files $uri $uri/ /index.html;
+        }       
+            
+
+        proxy_cache images_cache;
+        # Reverse proxy to ${DRIVEBC_IMAGE_API_BASE_URL} Webcam (includes caching)
+        location /webcam/ {
+                proxy_ssl_server_name on;
+                proxy_pass ${DRIVEBC_IMAGE_API_BASE_URL};
+                proxy_connect_timeout 5s;
+                proxy_cache_background_update on;
+                proxy_cache_lock on;
+                proxy_cache_lock_age 10s;
+                proxy_cache_lock_timeout 10s;
+                proxy_cache_revalidate on;
+                proxy_cache_use_stale error timeout updating http_502 http_503 http_504;
+                proxy_cache_valid 200 1m;
+                add_header X-Proxy-Cache $upstream_cache_status;
+        }
+        # Reverse proxy to ${DRIVEBC_IMAGE_API_BASE_URL} ReplayTheDay (includes caching)
+        location /ReplayTheDay/ {
+                proxy_ssl_server_name on;
+                proxy_pass ${DRIVEBC_IMAGE_API_BASE_URL};
+                proxy_connect_timeout 5s;
+                proxy_cache_background_update on;
+                proxy_cache_lock on;
+                proxy_cache_lock_age 10s;
+                proxy_cache_lock_timeout 10s;
+                proxy_cache_revalidate on;
+                proxy_cache_use_stale error timeout updating http_502 http_503 http_504;
+                proxy_cache_valid any 24h;
+                add_header X-Proxy-Cache $upstream_cache_status;
+        }
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+}
+}


### PR DESCRIPTION
Everything required to build the image caching image and getting it pushed into each of the environments.
Setting up the image streams, deployments, etc is separate in a later helm file