### PR TITLE
Feature/dbc22 1656

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -22,7 +22,7 @@ server {
     # Caching data from the API
     location /api/ {
             proxy_ssl_server_name on;
-            proxy_pass {ENVIRONMENT}-django/;
+            proxy_pass http://{ENVIRONMENT}-django/;
             proxy_connect_timeout 5s;
             proxy_cache_background_update on;
             proxy_cache_lock on;

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -22,7 +22,7 @@ server {
     # Caching data from the API
     location /api/ {
             proxy_ssl_server_name on;
-            proxy_pass {ENVIRONMENT}-django;
+            proxy_pass {ENVIRONMENT}-django/;
             proxy_connect_timeout 5s;
             proxy_cache_background_update on;
             proxy_cache_lock on;

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -22,7 +22,7 @@ server {
     # Caching data from the API
     location /api/ {
             proxy_ssl_server_name on;
-            proxy_pass ${ENVIRONMENT}-django;
+            proxy_pass {ENVIRONMENT}-django;
             proxy_connect_timeout 5s;
             proxy_cache_background_update on;
             proxy_cache_lock on;

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -1,39 +1,43 @@
-server {
-    listen       3000;
-    listen  [::]:3000;
-    server_name  localhost;
-
-    access_log /dev/null;
+http {
     proxy_cache_path /var/cache/nginx keys_zone=cache:50m;
 
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
-        auth_basic           "Beta Site";
-        auth_basic_user_file /etc/apache2/.htpasswd;
-    }
+    server {
+        listen       3000;
+        listen  [::]:3000;
+        server_name  localhost;
 
-    proxy_cache cache;
-    # Caching data from the API
-    location /api/ {
-        proxy_ssl_server_name on;
-        proxy_pass ${ENVIRONMENT}-django;
-        proxy_connect_timeout 5s;
-        proxy_cache_background_update on;
-        proxy_cache_lock on;
-        proxy_cache_lock_age 10s;
-        proxy_cache_lock_timeout 10s;
-        proxy_cache_revalidate on;
-        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-        proxy_cache_valid 200 1m;
-        add_header X-Proxy-Cache $upstream_cache_status;
-    }
+        access_log /dev/null;
+    
 
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri $uri/ /index.html;
+            auth_basic           "Beta Site";
+            auth_basic_user_file /etc/apache2/.htpasswd;
+        }
+
+        proxy_cache cache;
+        # Caching data from the API
+        location /api/ {
+            proxy_ssl_server_name on;
+            proxy_pass ${ENVIRONMENT}-django;
+            proxy_connect_timeout 5s;
+            proxy_cache_background_update on;
+            proxy_cache_lock on;
+            proxy_cache_lock_age 10s;
+            proxy_cache_lock_timeout 10s;
+            proxy_cache_revalidate on;
+            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            proxy_cache_valid 200 1m;
+            add_header X-Proxy-Cache $upstream_cache_status;
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
     }
 }

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -4,6 +4,7 @@ server {
     server_name  localhost;
 
     access_log /dev/null;
+    proxy_cache_path /var/cache/nginx keys_zone=cache:50m;
 
     location / {
         root   /usr/share/nginx/html;
@@ -11,6 +12,22 @@ server {
         try_files $uri $uri/ /index.html;
         auth_basic           "Beta Site";
         auth_basic_user_file /etc/apache2/.htpasswd;
+    }
+
+    proxy_cache cache;
+    # Caching data from the API
+    location /api/ {
+        proxy_ssl_server_name on;
+        proxy_pass ${ENVIRONMENT}-django;
+        proxy_connect_timeout 5s;
+        proxy_cache_background_update on;
+        proxy_cache_lock on;
+        proxy_cache_lock_age 10s;
+        proxy_cache_lock_timeout 10s;
+        proxy_cache_revalidate on;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_valid 200 1m;
+        add_header X-Proxy-Cache $upstream_cache_status;
     }
 
     # redirect server error pages to the static page /50x.html

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -22,7 +22,7 @@ server {
     # Caching data from the API
     location /api/ {
             proxy_ssl_server_name on;
-            proxy_pass http://{ENVIRONMENT}-django/;
+            proxy_pass http://{ENVIRONMENT}-django;
             proxy_connect_timeout 5s;
             proxy_cache_background_update on;
             proxy_cache_lock on;

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -1,25 +1,26 @@
-http {
-    proxy_cache_path /var/cache/nginx keys_zone=cache:50m;
 
-    server {
-        listen       3000;
-        listen  [::]:3000;
-        server_name  localhost;
+proxy_temp_path /tmp/proxy_temp;
+proxy_cache_path /var/cache/nginx keys_zone=cache:50m;
 
-        access_log /dev/null;
-    
+server {
+    listen       3000;
+    listen  [::]:3000;
+    server_name  localhost;
 
-        location / {
-            root   /usr/share/nginx/html;
-            index  index.html index.htm;
-            try_files $uri $uri/ /index.html;
-            auth_basic           "Beta Site";
-            auth_basic_user_file /etc/apache2/.htpasswd;
-        }
+    access_log /dev/null;
 
-        proxy_cache cache;
-        # Caching data from the API
-        location /api/ {
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+        auth_basic           "Beta Site";
+        auth_basic_user_file /etc/apache2/.htpasswd;
+    }
+
+    proxy_cache cache;
+    # Caching data from the API
+    location /api/ {
             proxy_ssl_server_name on;
             proxy_pass ${ENVIRONMENT}-django;
             proxy_connect_timeout 5s;
@@ -33,11 +34,10 @@ http {
             add_header X-Proxy-Cache $upstream_cache_status;
         }
 
-        # redirect server error pages to the static page /50x.html
-        #
-        error_page   500 502 503 504  /50x.html;
-        location = /50x.html {
-            root   /usr/share/nginx/html;
-        }
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
     }
 }

--- a/compose/frontend/entrypoint
+++ b/compose/frontend/entrypoint
@@ -11,7 +11,7 @@ echo -e "window.ROUTE_PLANNER_KEY='${REACT_APP_ROUTE_PLANNER_KEY}';" >> $MAIN
 echo -e "window.REPLAY_THE_DAY='${REACT_APP_REPLAY_THE_DAY}';" >> $MAIN
 
 # Set the environment to be used for caching django content
-sed -i "s~\ENVIRONMENT~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
+sed -i "s~{ENVIRONMENT}~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
 
 #FOLLOWING SECTION IS TEMPORARY FOR THE PRIVATE BETA
 # Check if $ENVIRONMENT is not set to "prod". If it is prod we want to keep these lines

--- a/compose/frontend/entrypoint
+++ b/compose/frontend/entrypoint
@@ -11,7 +11,7 @@ echo -e "window.ROUTE_PLANNER_KEY='${REACT_APP_ROUTE_PLANNER_KEY}';" >> $MAIN
 echo -e "window.REPLAY_THE_DAY='${REACT_APP_REPLAY_THE_DAY}';" >> $MAIN
 
 # Set the environment to be used for caching django content
-sed -i "s~\$ENVIRONMENT~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
+sed -i "s~\ENVIRONMENT~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
 
 #FOLLOWING SECTION IS TEMPORARY FOR THE PRIVATE BETA
 # Check if $ENVIRONMENT is not set to "prod". If it is prod we want to keep these lines

--- a/compose/frontend/entrypoint
+++ b/compose/frontend/entrypoint
@@ -10,6 +10,9 @@ echo -e "window.ROUTE_PLANNER='${REACT_APP_ROUTE_PLANNER}';" >> $MAIN
 echo -e "window.ROUTE_PLANNER_KEY='${REACT_APP_ROUTE_PLANNER_KEY}';" >> $MAIN
 echo -e "window.REPLAY_THE_DAY='${REACT_APP_REPLAY_THE_DAY}';" >> $MAIN
 
+# Set the environment to be used for caching django content
+sed -i "s~\$ENVIRONMENT~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
+
 #FOLLOWING SECTION IS TEMPORARY FOR THE PRIVATE BETA
 # Check if $ENVIRONMENT is not set to "prod". If it is prod we want to keep these lines
 if [ "$ENVIRONMENT" != "prod" ]; then

--- a/src/caching/nginx.conf.template
+++ b/src/caching/nginx.conf.template
@@ -76,20 +76,6 @@ http {
                 add_header X-Proxy-Cache $upstream_cache_status;
         }
 
-        # Reverse proxy to ${DRIVEBC_IMAGE_BASE_URL} bchighwaycamp url
-        location /bchighwaycam/ {
-                proxy_ssl_server_name on;
-                proxy_pass ${DRIVEBC_IMAGE_BASE_URL};
-                proxy_connect_timeout 5s;
-                proxy_cache_background_update on;
-                proxy_cache_lock on;
-                proxy_cache_lock_age 10s;
-                proxy_cache_lock_timeout 10s;
-                proxy_cache_revalidate on;
-                proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-                proxy_cache_valid 200 1m;
-                add_header X-Proxy-Cache $upstream_cache_status;
-        }
         error_page 404 /404.html;
             location = /40x.html {
         }

--- a/src/caching/nginx.conf.template
+++ b/src/caching/nginx.conf.template
@@ -75,6 +75,21 @@ http {
                 proxy_cache_valid any 24h;
                 add_header X-Proxy-Cache $upstream_cache_status;
         }
+
+        # Reverse proxy to ${DRIVEBC_IMAGE_BASE_URL} bchighwaycamp url
+        location /bchighwaycam/ {
+                proxy_ssl_server_name on;
+                proxy_pass ${DRIVEBC_IMAGE_BASE_URL};
+                proxy_connect_timeout 5s;
+                proxy_cache_background_update on;
+                proxy_cache_lock on;
+                proxy_cache_lock_age 10s;
+                proxy_cache_lock_timeout 10s;
+                proxy_cache_revalidate on;
+                proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+                proxy_cache_valid 200 1m;
+                add_header X-Proxy-Cache $upstream_cache_status;
+        }
         error_page 404 /404.html;
             location = /40x.html {
         }

--- a/src/caching/nginx.conf.template
+++ b/src/caching/nginx.conf.template
@@ -19,16 +19,15 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" $upstream_cache_status $request_time';
 
     access_log /dev/null;
-    #may want to look at setting up some cache logging to see what % of files are stale etc
     
     sendfile        on;
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-    proxy_cache_path /var/cache/nginx keys_zone=images_cache:10m;
+    proxy_cache_path /var/cache/nginx keys_zone=images_cache:100m;
     #gzip  on;
     server {
         listen       8080 default_server;
@@ -58,7 +57,7 @@ http {
                 proxy_cache_lock_age 10s;
                 proxy_cache_lock_timeout 10s;
                 proxy_cache_revalidate on;
-                proxy_cache_use_stale error timeout updating http_502 http_503 http_504;
+                proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
                 proxy_cache_valid 200 1m;
                 add_header X-Proxy-Cache $upstream_cache_status;
         }
@@ -72,7 +71,7 @@ http {
                 proxy_cache_lock_age 10s;
                 proxy_cache_lock_timeout 10s;
                 proxy_cache_revalidate on;
-                proxy_cache_use_stale error timeout updating http_502 http_503 http_504;
+                proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
                 proxy_cache_valid any 24h;
                 add_header X-Proxy-Cache $upstream_cache_status;
         }


### PR DESCRIPTION
Add support for caching api calls going to Django. This includes webcam, cms, events, etc
NOTE: This does not include anything django-media, django-static etc
I also made a change to image caching so that it doesn't server stale images while updating anymore.

Changes that need to be made in openshift:
1. Ensure that there is an environment variable called ENVIRONMENT under ENV-static-frontend with the environment you are in (Already Done)
2. Update the ENV-drivebc-django configmap to include ,.svc.cluster.local,ENV-django (Already done)
3. Once deployed, update the route for ENV-django-api by clicking ... then Edit Route. Change the path from /api/ to /api-old/. This will ensure that all calls go through the frontend which proxies the requests. 
4. To verify it's working, go to your browser and inspect a webcam page like this: https://dev-drivebc.apps.silver.devops.gov.bc.ca/cameras/612. If you see X-Proxy-Cache then you know it's going through the cache.