### PR TITLE
DBC22-1486: Added styling and html structure for regional weather sidepanel

### DIFF
--- a/src/frontend/src/Components/map/mapPopup.js
+++ b/src/frontend/src/Components/map/mapPopup.js
@@ -12,8 +12,13 @@ import {
   faMountain,
   faDroplet,
   faSnowflake,
-  faWind
+  faWind,
+  faEye,
+  faArrowUpRightFromSquare
 } from '@fortawesome/free-solid-svg-icons';
+import {
+  faSunCloud
+} from '@fortawesome/pro-solid-svg-icons';
 
 import './mapPopup.scss';
 
@@ -107,6 +112,7 @@ export function getFerryPopup(ferryFeature) {
       </div>
     </div>
 
+    // Road weather conditions html structure
     // <div className="popup popup--road-weather">
     //   <div className="popup__title">
     //     <div className="popup__title__icon">
@@ -176,6 +182,47 @@ export function getFerryPopup(ferryFeature) {
 
     //       </div>
     //     </div>
+    //   </div>
+    // </div>
+
+    // Regional weather html structure
+    // <div className="popup popup--regional-weather">
+    //   <div className="popup__title">
+    //     <div className="popup__title__icon">
+    //       <FontAwesomeIcon icon={faSunCloud} />
+    //     </div>
+    //     <p className="name">Regional Weather</p>
+    //   </div>
+    //   <div className="popup__content">
+    //     <div className="popup__content__title">
+    //       <p className="name">Cummins Lakes Park</p>
+    //       <FriendlyTime date='2024-03-01T00:00:00-08:00' />
+    //     </div>
+    //     <div className="popup__content__description">
+    //       <FontAwesomeIcon className="weather-icon" icon={faSunCloud} />
+    //       <p className="weather">Partly cloudy</p>
+    //       <p className="temperature">24&#x2103;</p>
+    //       <div className="data-card">
+    //         <div className="data-card__row">
+    //           <div className="data-icon">
+    //             <FontAwesomeIcon className="icon" icon={faEye} />
+    //           </div>
+    //           <p className="label">Visibility</p>
+    //          <p className="data">42km</p>
+    //        </div>
+    //        <div className="data-card__row">
+    //           <div className="data-icon">
+    //             <FontAwesomeIcon className="icon" icon={faWind} />
+    //           </div>
+    //           <p className="label">Wind</p>
+    //          <p className="data">SW 27 gusts 44 km/h</p>
+    //        </div>
+    //       </div>
+    //     </div>
+    //   </div>
+    //   <div className="popup__additional">
+    //     <p className="label"><a alt="Past 24 Hours" target="_self" href="https://weather.gc.ca/past_conditions/index_e.html?station=yyj">Past 24 hours <FontAwesomeIcon icon={faArrowUpRightFromSquare} /></a></p>
+    //     <p className="label">Courtesy of <a alt="Environment Canada" target="_self" href="https://weather.gc.ca/canada_e.html">Environment Canada <FontAwesomeIcon icon={faArrowUpRightFromSquare} /></a></p>
     //   </div>
     // </div>
   );

--- a/src/frontend/src/Components/map/mapPopup.js
+++ b/src/frontend/src/Components/map/mapPopup.js
@@ -6,7 +6,14 @@ import EventTypeIcon from '../EventTypeIcon';
 import FriendlyTime from '../FriendlyTime';
 import parse from 'html-react-parser';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFerry } from '@fortawesome/free-solid-svg-icons';
+import { 
+  faFerry,
+  faTemperatureHalf,
+  faMountain,
+  faDroplet,
+  faSnowflake,
+  faWind
+} from '@fortawesome/free-solid-svg-icons';
 
 import './mapPopup.scss';
 
@@ -56,7 +63,6 @@ export function getEventPopup(eventFeature) {
         <div className="popup__title__icon">
           <EventTypeIcon event={eventData} state='active' />
         </div>
-        {console.log(eventData)}
         <p className="name">{convertCategory(eventData)}</p>
       </div>
       <div className="popup__content">
@@ -100,5 +106,77 @@ export function getFerryPopup(ferryFeature) {
         </div>
       </div>
     </div>
+
+    // <div className="popup popup--road-weather">
+    //   <div className="popup__title">
+    //     <div className="popup__title__icon">
+    //       <FontAwesomeIcon icon={faTemperatureHalf} />
+    //     </div>
+    //     <p className="name">Local Weather</p>
+    //     <span className="sub-name">Weather Stations</span>
+    //   </div>
+    //   <div className="popup__content">
+    //     <div className="popup__content__title">
+    //       <p className="name">Trout Creek</p>
+    //       <FriendlyTime date='2024-03-01T00:00:00-08:00' />
+    //       <p className="description">Southside of Highway 15, 22km northwest of Smithers.</p>
+    //     </div>
+    //     <div className="popup__content__description">
+    //       <div className="road-condition">
+    //         <p className="data">Packed snow of 5cm</p>
+    //         <p className="label">Road Condition</p>
+    //       </div>
+    //       <div className="temperatures">
+    //         <div className="temperature temperature--air">
+    //           <p className="data">17&#x2103;</p>
+    //           <p className="label">Air</p>
+    //         </div>
+    //         <div className="temperature temperature--road">
+    //           <p className="data">22&#x2103;</p>
+    //           <p className="label">Road</p>
+    //         </div>
+    //       </div>
+    //       <div className="data-card">
+    //         <div className="data-card__row">
+    //           <div className="data-icon">
+    //             <FontAwesomeIcon className="icon" icon={faMountain} />
+    //           </div>
+    //           <p className="label">Elevation</p>
+    //           <p className="data">410m</p>
+    //         </div>
+    //         <div className="data-card__row">
+    //           <div className="data-icon">
+    //             <FontAwesomeIcon className="icon" icon={faDroplet} />
+    //           </div>
+    //           <p className="label">Precipitation (last 12 hours)</p>
+    //           <p className="data">240mm</p>
+    //         </div>
+    //         <div className="data-card__row">
+    //           <div className="data-icon">
+    //             <FontAwesomeIcon className="icon" icon={faSnowflake} />
+    //           </div>
+    //           <p className="label">Snow (last 12 hours)</p>
+    //           <p className="data">240cm</p>
+    //         </div>
+    //         <div className="data-card__row data-card__row group">
+    //           <div className="data-icon">
+    //             <FontAwesomeIcon className="icon" icon={faWind} />
+    //           </div>
+    //           <div className="data-group">
+    //             <div className="data-group__row">
+    //               <p className="label">Average wind</p>
+    //               <p className="data">SE 15 km/h</p>
+    //             </div>
+    //             <div className="data-group__row">
+    //               <p className="label">Maximum wind</p>
+    //               <p className="data">20 km/h</p>
+    //             </div>
+    //           </div>
+    //         </div>
+
+    //       </div>
+    //     </div>
+    //   </div>
+    // </div>
   );
 }

--- a/src/frontend/src/Components/map/mapPopup.scss
+++ b/src/frontend/src/Components/map/mapPopup.scss
@@ -298,56 +298,134 @@
             }
           }
         }
-        .data-card {
-          margin-top: 0.75rem;
-          padding: 0.75rem;
-          border-radius: 8px;
-          box-shadow: 0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.13), 0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.10);
+      }
+    }
+  }
 
-          &__row {
-            display: flex;
+  //Regional Weather layer
+  &--regional-weather {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 
-            & + .data-card__row {
-              margin-top: 0.75rem;
-              padding-top: 0.75rem;
-              border-top: 1px solid $Divider;
-            }
+    .popup__title {
+      background-color: #ECEAE8;
+      border-top: 4px solid $Type-Primary;
+      
+      .name {
+        color: $Type-Primary;
+      }
+  
+      &__icon {
+        background-color: $Type-Primary;
+        color: white;
+      }
+    }
 
-            &:not(.group) {
-              .data-icon {
-                align-self: center;
-              }
-            }
+    .popup__content {
+      p {
+        margin-bottom: 0;
+      }
+      &__title {
+        .name {
+          color: $Type-Primary;
+          font-size: 2.25rem;
+          text-align: center;
+          margin-bottom: 0;
+        }
 
-            .data-icon {
-              margin-right: 0.75rem;
-            }
-
-            .data-group {
-              flex: 1 0;
-
-              &__row {
-                display: flex;
-              }
-            }
-          }
-
-          .label, .data {
+        .friendly-time {
+          margin: 0 auto 1rem;
+          &-text {
+            color: $Type-Secondary;
             font-size: 0.875rem;
-          }
-          
-          .label {
-            text-align: left;
-            font-weight: 700;
-          }
-
-          .data {
-            text-align: right;
-            margin-left: auto;
-            min-width: 80px;
           }
         }
       }
+      &__description {
+        text-align: center;
+        .weather-icon {
+          font-size: 4rem;
+        }
+        .weather {
+          font-size: 0.875rem;
+        }
+        .temperature {
+          font-size: 4rem;
+          font-weight: 700;
+        }
+      }
+    }
+
+    .popup__additional {
+      padding: 0.5rem 1rem;
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      justify-content: space-between;
+      
+      p {
+        text-align: center;
+        color: $Type-Secondary;
+        a {
+          svg {
+            color: $Type-Secondary;
+          }
+        }
+      }
+    }
+  }
+
+  //common styles for Road weather and Regional weather
+  .data-card {
+    margin: 0.75rem 0;
+    padding: 0.75rem;
+    border-radius: 8px;
+    box-shadow: 0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.13), 0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.10);
+
+    &__row {
+      display: flex;
+
+      & + .data-card__row {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid $Divider;
+      }
+
+      &:not(.group) {
+        .data-icon {
+          align-self: center;
+        }
+      }
+
+      .data-icon {
+        margin-right: 0.75rem;
+      }
+
+      .data-group {
+        flex: 1 0;
+
+        &__row {
+          display: flex;
+        }
+      }
+    }
+
+    .label, .data {
+      font-size: 0.875rem;
+      margin-bottom: 0;
+    }
+    
+    .label {
+      text-align: left;
+      font-weight: 700;
+    }
+
+    .data {
+      text-align: right;
+      margin-left: auto;
+      min-width: 80px;
+      color: $Type-Secondary;
     }
   }
 }

--- a/src/frontend/src/Components/map/mapPopup.scss
+++ b/src/frontend/src/Components/map/mapPopup.scss
@@ -227,5 +227,128 @@
       }
     }
   }
+
+  //Road Weather layer
+  &--road-weather {
+    .popup__title {
+      background-color: #ECEAE8;
+      border-top: 4px solid $Type-Primary;
+      
+      .name {
+        color: $Type-Primary;
+      }
+
+      .sub-name {
+        font-size: 0.875rem;
+        color: $Grey70;
+      }
+  
+      &__icon {
+        background-color: $Type-Primary;
+        color: white;
+      }
+    }
+
+    .popup__content {
+      text-align: center;
+      p {
+        margin-bottom: 0;
+      }
+      &__title {
+        margin: 1rem 1rem 0;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid $Divider;
+
+        .name {
+          color: $Type-Primary;
+          font-size: 2.25rem;
+        }
+
+        .friendly-time {
+          margin: 0 auto 1rem;
+          &-text {
+            color: $Type-Secondary;
+            font-size: 0.875rem;
+          }
+        }
+
+        .description {
+          margin-top: 1rem;
+          font-size: 0.875rem;
+        }
+      }
+      &__description {
+        & > div {
+          padding-bottom: 1rem;
+        }
+        .road-condition {
+          .data {
+            font-size: 1.25rem;
+            font-weight: 700;
+          }
+        }
+        .temperatures {
+          display: flex;
+          justify-content: space-around;
+
+          .temperature {
+            .data {
+              font-size: 2.25rem;
+              font-weight: 700;
+            }
+          }
+        }
+        .data-card {
+          margin-top: 0.75rem;
+          padding: 0.75rem;
+          border-radius: 8px;
+          box-shadow: 0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.13), 0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.10);
+
+          &__row {
+            display: flex;
+
+            & + .data-card__row {
+              margin-top: 0.75rem;
+              padding-top: 0.75rem;
+              border-top: 1px solid $Divider;
+            }
+
+            &:not(.group) {
+              .data-icon {
+                align-self: center;
+              }
+            }
+
+            .data-icon {
+              margin-right: 0.75rem;
+            }
+
+            .data-group {
+              flex: 1 0;
+
+              &__row {
+                display: flex;
+              }
+            }
+          }
+
+          .label, .data {
+            font-size: 0.875rem;
+          }
+          
+          .label {
+            text-align: left;
+            font-weight: 700;
+          }
+
+          .data {
+            text-align: right;
+            margin-left: auto;
+            min-width: 80px;
+          }
+        }
+      }
+    }
+  }
 }
 

--- a/src/frontend/src/styles/variables.scss
+++ b/src/frontend/src/styles/variables.scss
@@ -1,6 +1,6 @@
 //Type
 $Type-Primary: #292929;
-$Type-Secondary: #464341;
+$Type-Secondary: #474543;
 $Type-Disabled: #A19F9D;
 $Type-Link: #1A5A96;
 


### PR DESCRIPTION
Similar to the road weather sidepanel DBC22-1732, worked ahead with styling the sidepanel for regional weather with dummy data.

This branch is based off of the branch for the road weather sidepanel feature/DBC22-1732, so either merge in only this branch to have both, or please rebase and merge this one after that one.

The html structure to use for the regional weather sidepanel can be found commented out in Map.js file under the block with class name "popup--regional-weather".