### PR TITLE
DBC22-2350: Filter out invalid access log lines

### DIFF
--- a/compose/openshiftjobs/scripts/analyzeexportlogs.sh
+++ b/compose/openshiftjobs/scripts/analyzeexportlogs.sh
@@ -75,7 +75,7 @@ if [ ${#zipped_files[@]} -gt 0 ]; then
 
     #Run goaccess on all the log files from the date entered
     goaccess_report_name=$start_time_formatted-goaccess_report.html
-    zcat "${zipped_files[@]}" | goaccess - -o "$goaccess_report_name" --log-format='~h{, } %e %^[%x] "%r" %s %b "%R" "%u" %C "%M" %T' --datetime-format='%d/%b/%Y:%H:%M:%S %z' --ignore-panel=REMOTE_USER --ignore-panel=ASN --tz=America/Vancouver --jobs=2 --geoip-database=$mmdb_file
+    zcat "${zipped_files[@]}" | grep -v '^-\s' | goaccess - -o "$goaccess_report_name" --log-format='~h{, } %e %^[%x] "%r" %s %b "%R" "%u" %C "%M" %T' --datetime-format='%d/%b/%Y:%H:%M:%S %z' --ignore-panel=REMOTE_USER --ignore-panel=ASN --tz=America/Vancouver --jobs=2 --geoip-database=$mmdb_file
     echo "GoAccess report generated successfully at $goaccess_report_name"
 
     # Get the start date formated in YYYY/MM/DD format


### PR DESCRIPTION
Due to a sysdig change, it looks like it broke goaccess log analyzing by causing access log entries like this:
`- - - [21/Jun/2024:06:49:57 +0000] "GET /nginx_status/ HTTP/1.1" 200 594 "-" "Sysdig Agent/1.0" - "text/html" 0.000 `
Goaccess requires a host IP which this doesn't have, which was causing the jobs to fail.
This fix will need to go to all environments sooner than later