### PR TITLE
DBC22-2249: fixed advisories in view behavior for side panel

### DIFF
--- a/src/frontend/src/Components/advisories/AdvisoriesOnMap.js
+++ b/src/frontend/src/Components/advisories/AdvisoriesOnMap.js
@@ -5,16 +5,13 @@ import React from 'react';
 import trackEvent from '../shared/TrackEvent';
 import { resetClickedStates } from '../map/handlers/click';
 
-// Third party packages
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {
-  faFlag
-} from '@fortawesome/pro-solid-svg-icons';
+// External imports
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFlag } from '@fortawesome/pro-solid-svg-icons';
 import Button from 'react-bootstrap/Button';
 
 // Styling
 import './AdvisoriesOnMap.scss';
-
 
 
 export default function AdvisoriesOnMap(props) {

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -414,7 +414,7 @@ export default function DriveBCMap(props) {
         </button>
 
         <div className="panel-content">
-          {openPanel && renderPanel(clickedFeature && !clickedFeature.get ? (smallScreen ? advisories : advisoriesInView) : clickedFeature , isCamDetail)}
+          {openPanel && renderPanel(clickedFeature && !clickedFeature.get ? advisoriesInView : clickedFeature , isCamDetail)}
         </div>
       </div>
 
@@ -425,10 +425,7 @@ export default function DriveBCMap(props) {
               <ExitSurvey mobile={true} />
             )}
             <RouteSearch routeEdit={true} />
-            {smallScreen ?
-              <AdvisoriesOnMap advisories={advisories} updateClickedFeature={updateClickedFeature} open={openPanel} clickedFeature={clickedFeature} clickedFeatureRef={clickedFeatureRef} />
-              : <AdvisoriesOnMap advisories={advisoriesInView} updateClickedFeature={updateClickedFeature} open={openPanel} clickedFeature={clickedFeature} clickedFeatureRef={clickedFeatureRef} />
-            }
+              <AdvisoriesOnMap advisories={advisoriesInView} updateClickedFeature={updateClickedFeature} open={openPanel} clickedFeature={clickedFeature} clickedFeatureRef={clickedFeatureRef} />
           </div>
         )}
 

--- a/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
+++ b/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
@@ -1,5 +1,5 @@
 // React
-import React from 'react';
+import React, { useState } from 'react';
 
 // Third party packages
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -14,6 +14,9 @@ import './AdvisoriesPanel.scss';
 export default function AdvisoriesPanel(props) {
   const { advisories } = props;
 
+  // Intentionally using useState to avoid modifying the original array
+  const [advisoriesDisplay] = useState(advisories);
+
   return (
     <div className="popup popup--advisories" tabIndex={0}>
       <div className="popup__title">
@@ -23,7 +26,7 @@ export default function AdvisoriesPanel(props) {
         <p className="name">Advisories</p>
       </div>
       <div className="popup__content">
-        <AdvisoriesList advisories={advisories} showDescription={false} showTimestamp={false} showArrow={true} />
+        <AdvisoriesList advisories={advisoriesDisplay} showDescription={false} showTimestamp={false} showArrow={true} />
       </div>
     </div>
   );


### PR DESCRIPTION
[DBC22-2249](https://jira.th.gov.bc.ca/browse/DBC22-2249)

@minORC this bug was a result of us trying to work around the mobile advisories bug where the advisories popup panel eats up the map viewport which could result in a blank panel.

To solve this, we are now using advisoriesInView everywhere, but in AdvisoriesPanel we are no longer directly displaying advisories from the prop; we're mapping to a state and intentionally _not_ using a useEffect call to update it. Essentially this "snapshots" the panel display to what was showing on the map at the time of the click.