### PR TITLE
DBC22-2421: Update Alpine Image for OpenShiftJobs

### DIFF
--- a/compose/openshiftjobs/DockerFile
+++ b/compose/openshiftjobs/DockerFile
@@ -1,12 +1,11 @@
-FROM alpine:3.19
+FROM alpine:3.20
 RUN apk update && apk upgrade
-#Need goaccess 1.92 for a timezone fix. Once that version is in the regular branch, we can pull it from there.
-RUN apk add goaccess --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
 
 RUN apk add --no-cache \
     aws-cli \
     bash \
     coreutils \
+    goaccess \
     tzdata
 
 COPY ./compose/openshiftjobs/entrypoint.sh /


### PR DESCRIPTION
With this update I can remove a workaround to get the version of goaccess I needed working.