### PR TITLE
DBC22-2448: Improved logic to identify timestamps

### DIFF
--- a/compose/openshiftjobs/scripts/analyzeexportlogs.sh
+++ b/compose/openshiftjobs/scripts/analyzeexportlogs.sh
@@ -30,7 +30,7 @@ for file in *.gz; do
     # Check if the file exists and is a regular file
     if [[ -f $file ]]; then
         # Extract the date and time part from the filename (assuming UTC timezone)
-        file_datetime_utc=$(echo "$file" | grep -oE '[0-9]{10}')
+        file_datetime_utc=$(echo "$file" | sed -n 's/.*\([0-9]\{10\}\)-access\.log\.gz/\1/p')
         # Check if the file date and time in UTC falls within days_ago's start and end time in UTC
         if [[ $file_datetime_utc -ge $start_time_utc && $file_datetime_utc -le $end_time_utc ]]; then
             zipped_files+=("$file")

--- a/compose/openshiftjobs/scripts/ziplogs.sh
+++ b/compose/openshiftjobs/scripts/ziplogs.sh
@@ -10,7 +10,7 @@ log_dir="./logs"
 # Iterate over log files
 find "$log_dir" -type f -name '*.log' | while read -r file; do
     # Extract timestamp from filename
-    timestamp=$(echo "$file" | grep -oE '[0-9]{10}')
+    timestamp=$(echo "$file" | sed -n 's/.*\([0-9]\{10\}\)-access\.log/\1/p')
 
     # Check if timestamp is less than or equal to previous hour
     if [[ $timestamp -le $previous_hour ]]; then


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-2448
There is a scenario where the pod name can have a 10 digit # in it which breaks the grep logic used to find the timestamp in the logfile. This update addresses that by looking for -access.log after the timestamp. Alpine didn't seem to support grep lookahead so using sed instead