### PR TITLE
DBC22-2401: fixed map moving when side panel open and close

### DIFF
--- a/src/frontend/src/Components/map/Map.scss
+++ b/src/frontend/src/Components/map/Map.scss
@@ -33,6 +33,8 @@
     align-items: center;
     height: 100%;
 
+    
+
     @media (max-width: 767px) {
       flex-direction: column;
     }
@@ -58,7 +60,6 @@
       flex: 0;
       min-width: 0px;
       min-height: 0%;
-      transition: min-width 0.25s ease-in-out;
       overflow-y: auto;
       overflow-x: hidden;
       display: flex;
@@ -183,6 +184,8 @@
       height: 100%;
       overflow: hidden;
 
+      
+
       .map-left-container {
         position: absolute;
         width: 100%;
@@ -250,6 +253,13 @@
         will-change: contents, width;
         transition: all 0.25s;
       }
+    }
+
+    .map-pushed {
+      margin-left: -390px;
+    }
+    .map-not-pushed {
+      margin-left: 0px;
     }
 
     .map-btn {


### PR DESCRIPTION
DBC22-2401: fixed map moving when side panel open and close.
This PR created a function to adjust the map window for setting css classes of the map. Basically the map moving when opening or closing the side panel was caused by the margin left value, so the function intent to update the margin left to make sure the map classes can be set properly.
Jira: https://jira.th.gov.bc.ca/browse/DBC22-2401