### PR TITLE
DBC22-1722:Update geocoder parameters

### DIFF
--- a/src/frontend/src/Components/data/locations.js
+++ b/src/frontend/src/Components/data/locations.js
@@ -2,12 +2,13 @@ import { get } from "./helper.js";
 
 export function getLocations(addressInput) {
   return get(`${window.GEOCODER_HOST}/addresses.json`, {
-      minScore: 65,
-      maxResults: 20,
+      minScore: 50,
+      maxResults: 7,
       echo: 'false',
       brief: true,
       autoComplete: true,
-      addressString: addressInput
+      addressString: addressInput,
+      locationDescriptor: 'routingPoint' 
     }, {
       'apiKey': `${window.GEOCODER_API_AUTH_KEY}`,
     }


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-1722

Updating the parameters for querying the geocoder to more closely match what is used on the geocoder demo page here: https://bcgov.github.io/ols-devkit/ols-demo/index.html

Changes include

- Minscore now 50 instead of 65 which means you should see results as early as you enter your first 3 characters (prior to this it would often take 6+ characters) 
- maxResults now 7 instead of 20. The demo page had 5, but in consultation with Chris and James we settled on 7 for DriveBC. 
- locationDescriptor is a new parameter. Demo page had parcelPoint, but in reading the documentation, routingPoint is more appropriate "A point lying on a road centreline and directly in front of a site's accessPoint. A routing point is intended for use by routing algorithms to finding routes between addresses."
