### PR TITLE
DBC22-2509: filters loading states in maps

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -145,6 +145,15 @@ export default function DriveBCMap(props) {
     roadConditions: null,
     advisories: null
   });
+  const [loadingLayers, setLoadingLayers] = useState({
+    cameras: mapContext.visible_layers.highwayCams,
+    events: mapContext.visible_layers.closures || mapContext.visible_layers.majorEvents ||
+      mapContext.visible_layers.minorEvents || mapContext.visible_layers.roadConditions ||
+      mapContext.visible_layers.futureEvents,
+    ferries: mapContext.visible_layers.inlandFerries,
+    weathers: mapContext.visible_layers.weather,
+    restStops: mapContext.visible_layers.restStops
+  });
 
   // Workaround for OL handlers not being able to read states
   const [clickedFeature, setClickedFeature] = useState();
@@ -343,14 +352,14 @@ export default function DriveBCMap(props) {
       loadLayer(
         mapLayers, mapRef, mapContext,
         'highwayCams', finalCameras, 78,
-        referenceData, updateReferenceFeature
+        referenceData, updateReferenceFeature, setLoadingLayers
       );
     }
   }, [filteredCameras]);
 
   // Events layer
   useEffect(() => {
-    loadEventsLayers(filteredEvents, mapContext, mapLayers, mapRef, referenceData, updateReferenceFeature);
+    loadEventsLayers(filteredEvents, mapContext, mapLayers, mapRef, referenceData, updateReferenceFeature, setLoadingLayers);
 
     // Count filtered events to store in routeDetails
     if (filteredEvents) {
@@ -377,7 +386,7 @@ export default function DriveBCMap(props) {
       loadLayer(
         mapLayers, mapRef, mapContext,
         'inlandFerries', filteredFerries, 68,
-        referenceData, updateReferenceFeature
+        referenceData, updateReferenceFeature, setLoadingLayers
       );
     }
     // Add ferry count to routeDetails
@@ -393,7 +402,7 @@ export default function DriveBCMap(props) {
       loadLayer(
         mapLayers, mapRef, mapContext,
         'weather', filteredCurrentWeathers, 66,
-        referenceData, updateReferenceFeature
+        referenceData, updateReferenceFeature, setLoadingLayers
       );
     }
   }, [filteredCurrentWeathers]);
@@ -404,7 +413,7 @@ export default function DriveBCMap(props) {
       loadLayer(
         mapLayers, mapRef, mapContext,
         'regional', filteredRegionalWeathers, 67,
-        referenceData, updateReferenceFeature
+        referenceData, updateReferenceFeature, setLoadingLayers
       );
     }
   }, [filteredRegionalWeathers]);
@@ -415,13 +424,13 @@ export default function DriveBCMap(props) {
       loadLayer(
         mapLayers, mapRef, mapContext,
         'restStops', filteredRestStops, 68,
-        referenceData, updateReferenceFeature
+        referenceData, updateReferenceFeature, setLoadingLayers
       );
 
       loadLayer(
         mapLayers, mapRef, mapContext,
         'largeRestStops', filteredRestStops, 68,
-        referenceData, updateReferenceFeature
+        referenceData, updateReferenceFeature, setLoadingLayers
       );
     }
   }, [filteredRestStops]);
@@ -527,7 +536,7 @@ export default function DriveBCMap(props) {
               enableRoadConditions={true}
               isCamDetail={isCamDetail}
               referenceData={referenceData}
-            />
+              loadingLayers={loadingLayers} />
           </React.Fragment>
         )}
 
@@ -539,12 +548,14 @@ export default function DriveBCMap(props) {
               enableRoadConditions={true}
               isCamDetail={isCamDetail}
               referenceData={referenceData}
-            />
+              loadingLayers={loadingLayers} />
+
             <Button
               className="map-btn my-location"
               variant="primary"
               onClick={() => toggleMyLocation(mapRef, mapView)}
               aria-label="my location">
+
               <FontAwesomeIcon icon={faLocationCrosshairs} />
               My location
             </Button>
@@ -603,8 +614,7 @@ export default function DriveBCMap(props) {
           enableRoadConditions={true}
           textOverride={'Layer filters'}
           isCamDetail={isCamDetail}
-          referenceData={referenceData}
-        />
+          referenceData={referenceData} />
       )}
 
       {showNetworkError &&

--- a/src/frontend/src/Components/map/layers/camerasLayer.js
+++ b/src/frontend/src/Components/map/layers/camerasLayer.js
@@ -11,7 +11,7 @@ import VectorSource from 'ol/source/Vector';
 // Styling
 import { cameraStyles } from '../../data/featureStyleDefinitions.js';
 
-export function getCamerasLayer(cameras, projectionCode, mapContext, referenceData, updateReferenceFeature) {
+export function getCamerasLayer(cameras, projectionCode, mapContext, referenceData, updateReferenceFeature, setLoadingLayers) {
   return new VectorLayer({
     classname: 'webcams',
     visible: mapContext.visible_layers.highwayCams,
@@ -49,6 +49,11 @@ export function getCamerasLayer(cameras, projectionCode, mapContext, referenceDa
             });
           }
         });
+
+        setLoadingLayers(prevState => ({
+          ...prevState,
+          cameras: false
+        }));
       },
     }),
 

--- a/src/frontend/src/Components/map/layers/currentWeatherLayer.js
+++ b/src/frontend/src/Components/map/layers/currentWeatherLayer.js
@@ -11,7 +11,7 @@ import VectorSource from 'ol/source/Vector';
 // Styling
 import { roadWeatherStyles } from '../../data/featureStyleDefinitions.js';
 
-export function getCurrentWeatherLayer(weatherData, projectionCode, mapContext, referenceData, updateReferenceFeature) {
+export function getCurrentWeatherLayer(weatherData, projectionCode, mapContext, referenceData, updateReferenceFeature, setLoadingLayers) {
   return new VectorLayer({
     classname: 'weather',
     visible: mapContext.visible_layers.weather,
@@ -50,6 +50,11 @@ export function getCurrentWeatherLayer(weatherData, projectionCode, mapContext, 
             }
           }
         });
+
+        setLoadingLayers(prevState => ({
+          ...prevState,
+          weathers: false
+        }));
       },
     }),
     style: roadWeatherStyles['static'],

--- a/src/frontend/src/Components/map/layers/eventsLayer.js
+++ b/src/frontend/src/Components/map/layers/eventsLayer.js
@@ -8,7 +8,7 @@ import GeoJSON from 'ol/format/GeoJSON.js';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 
-export function loadEventsLayers(eventsData, mapContext, mapLayers, mapRef, referenceData, updateReferenceFeature) {
+export function loadEventsLayers(eventsData, mapContext, mapLayers, mapRef, referenceData, updateReferenceFeature, setLoadingLayers) {
   // Helper function for initializing vss
   const createVS = () => new VectorSource({
     format: new GeoJSON()
@@ -144,5 +144,10 @@ export function loadEventsLayers(eventsData, mapContext, mapLayers, mapRef, refe
     addLayer('futureEventsLines', futureEventsLinesVS, 12);
     addLayer('roadConditions', roadConditionsVS, 88);
     addLayer('roadConditionsLines', roadConditionsLinesVS, 8);
+
+    setLoadingLayers(prevState => ({
+      ...prevState,
+      events: false
+    }))
   }
 }

--- a/src/frontend/src/Components/map/layers/ferriesLayer.js
+++ b/src/frontend/src/Components/map/layers/ferriesLayer.js
@@ -11,7 +11,7 @@ import VectorSource from 'ol/source/Vector';
 // Styling
 import { ferryStyles } from '../../data/featureStyleDefinitions.js';
 
-export function getFerriesLayer(ferriesData, projectionCode, mapContext, referenceData, updateReferenceFeature) {
+export function getFerriesLayer(ferriesData, projectionCode, mapContext, referenceData, updateReferenceFeature, setLoadingLayers) {
   return new VectorLayer({
     classname: 'ferries',
     visible: mapContext.visible_layers.inlandFerries,
@@ -45,6 +45,11 @@ export function getFerriesLayer(ferriesData, projectionCode, mapContext, referen
             }
           }
         });
+
+        setLoadingLayers(prevState => ({
+          ...prevState,
+          ferries: false
+        }));
       },
     }),
     style: ferryStyles['static'],

--- a/src/frontend/src/Components/map/layers/index.js
+++ b/src/frontend/src/Components/map/layers/index.js
@@ -19,7 +19,7 @@ const layerFuncMap = {
   routeLayer: getRouteLayer,
 }
 
-export const loadLayer = (mapLayers, mapRef, mapContext, key, dataList, zIndex, referenceData, updateReferenceFeature) => {
+export const loadLayer = (mapLayers, mapRef, mapContext, key, dataList, zIndex, referenceData, updateReferenceFeature, setLoadingLayers) => {
   // Remove layer if it already exists
   if (mapLayers.current[key]) {
     mapRef.current.removeLayer(mapLayers.current[key]);
@@ -33,7 +33,8 @@ export const loadLayer = (mapLayers, mapRef, mapContext, key, dataList, zIndex, 
       mapRef.current.getView().getProjection().getCode(),
       mapContext,
       referenceData,
-      updateReferenceFeature
+      updateReferenceFeature,
+      setLoadingLayers
     );
 
     mapRef.current.addLayer(mapLayers.current[key]);

--- a/src/frontend/src/Components/map/layers/largeRestStopsLayer.js
+++ b/src/frontend/src/Components/map/layers/largeRestStopsLayer.js
@@ -12,7 +12,7 @@ import VectorSource from 'ol/source/Vector';
 import { restStopTruckStyles, restStopTruckClosedStyles } from '../../data/featureStyleDefinitions.js';
 import { isRestStopClosed } from '../../data/restStops.js';
 
-export function getLargeRestStopsLayer(restStopsData, projectionCode, mapContext, referenceData, updateReferenceFeature) {
+export function getLargeRestStopsLayer(restStopsData, projectionCode, mapContext, referenceData, updateReferenceFeature, setLoadingLayers) {
   return new VectorLayer({
     classname: 'largeRestStops',
     visible: mapContext.visible_layers.largeRestStops,
@@ -60,6 +60,11 @@ export function getLargeRestStopsLayer(restStopsData, projectionCode, mapContext
             }
           }
         }
+
+        setLoadingLayers(prevState => ({
+          ...prevState,
+          restStops: false
+        }));
       },
     }),
   });

--- a/src/frontend/src/Components/map/layers/regionalWeatherLayer.js
+++ b/src/frontend/src/Components/map/layers/regionalWeatherLayer.js
@@ -11,7 +11,7 @@ import VectorSource from 'ol/source/Vector';
 // Styling
 import { regionalStyles } from '../../data/featureStyleDefinitions.js';
 
-export function getRegionalWeatherLayer(weatherData, projectionCode, mapContext, referenceData, updateReferenceFeature) {
+export function getRegionalWeatherLayer(weatherData, projectionCode, mapContext, referenceData, updateReferenceFeature, setLoadingLayers) {
   return new VectorLayer({
     classname: 'regional',
     visible: mapContext.visible_layers.weather,
@@ -50,6 +50,11 @@ export function getRegionalWeatherLayer(weatherData, projectionCode, mapContext,
             }
           }
         });
+
+        setLoadingLayers(prevState => ({
+          ...prevState,
+          weathers: false
+        }));
       },
     }),
     style: regionalStyles['static'],

--- a/src/frontend/src/Components/map/layers/restStopsLayer.js
+++ b/src/frontend/src/Components/map/layers/restStopsLayer.js
@@ -12,7 +12,7 @@ import VectorSource from 'ol/source/Vector';
 import { restStopStyles, restStopClosedStyles, restStopTruckStyles, restStopTruckClosedStyles } from '../../data/featureStyleDefinitions.js';
 import { isRestStopClosed } from '../../data/restStops.js';
 
-export function getRestStopsLayer(restStopsData, projectionCode, mapContext, referenceData, updateReferenceFeature) {
+export function getRestStopsLayer(restStopsData, projectionCode, mapContext, referenceData, updateReferenceFeature, setLoadingLayers) {
   return new VectorLayer({
     classname: 'restStops',
     visible: mapContext.visible_layers.restStops,
@@ -66,6 +66,11 @@ export function getRestStopsLayer(restStopsData, projectionCode, mapContext, ref
             }
           }
         });
+
+        setLoadingLayers(prevState => ({
+          ...prevState,
+          restStops: false
+        }));
       },
     }),
   });

--- a/src/frontend/src/Components/shared/Filters.js
+++ b/src/frontend/src/Components/shared/Filters.js
@@ -1,7 +1,7 @@
 // React
 import React, { useState, useContext } from 'react';
 
-// Third party packages
+// External imports
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faFilter,
@@ -12,10 +12,13 @@ import {
   faFerry,
   faSunCloud,
 } from '@fortawesome/pro-solid-svg-icons';
+import { useMediaQuery } from '@uidotdev/usehooks';
 import Button from 'react-bootstrap/Button';
-import Tooltip from 'react-bootstrap/Tooltip';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import {useMediaQuery} from '@uidotdev/usehooks';
+import Spinner from 'react-bootstrap/Spinner';
+import Tooltip from 'react-bootstrap/Tooltip';
+
+// Internal imports
 import trackEvent from './TrackEvent';
 
 // Components and functions
@@ -40,6 +43,7 @@ export default function Filters(props) {
     textOverride,
     isCamDetail,
     referenceData,
+    loadingLayers,
     isDelaysPage
   } = props;
 
@@ -188,6 +192,10 @@ export default function Filters(props) {
                     <OverlayTrigger placement="top" overlay={tooltipClosures}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.events &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
 
                   <div className={'filter-item filter-item--major' + (majorEvents ? ' checked' : '')}>
@@ -214,6 +222,10 @@ export default function Filters(props) {
                     <OverlayTrigger placement="top" overlay={tooltipMajor}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.events &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
 
                   <div className={'filter-item filter-item--minor' + (minorEvents ? ' checked' : '')}>
@@ -240,6 +252,10 @@ export default function Filters(props) {
                     <OverlayTrigger placement="top" overlay={tooltipMinor}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.events &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
 
                   <div className={'filter-item filter-item--future-events' + (futureEvents ? ' checked' : '')}>
@@ -253,17 +269,22 @@ export default function Filters(props) {
                         setLayerVisibility('futureEventsLines', !futureEvents, false);
                         setFutureEvents(!futureEvents);
                       }}
-                      defaultChecked={eventCategory && eventCategory == 'futureEvents' ? true : mapContext.visible_layers.futureEvents}
-                    />
+                      defaultChecked={eventCategory && eventCategory == 'futureEvents' ? true : mapContext.visible_layers.futureEvents} />
+
                     <label htmlFor="filter--future-events">
                       <span className="filter-item__icon">
                         <FontAwesomeIcon icon={faCalendarDays} alt="future events" />
                       </span>
                       Future events
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipFutureevents}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.events &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
                 </div>
               </div>
@@ -284,17 +305,22 @@ export default function Filters(props) {
                         setHighwayCams(!highwayCams);
                       }}
                       defaultChecked={isCamDetail || mapContext.visible_layers.highwayCams}
-                      disabled={isCamDetail || disableFeatures}
-                    />
+                      disabled={isCamDetail || disableFeatures} />
+
                     <label htmlFor="filter--highway-cameras">
                       <span className="filter-item__icon">
                         <FontAwesomeIcon icon={faVideo} alt="highway cameras" />
                       </span>
                       Highway cameras
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipHighwaycameras}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.cameras &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
 
                   <div className={'filter-item filter-item--road-conditions' + (roadConditions ? ' checked' : '') + ((disableFeatures && !enableRoadConditions) ? ' disabled' : '')}>
@@ -319,9 +345,14 @@ export default function Filters(props) {
                       </span>
                       Road conditions
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipRoadconditions}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.events &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
 
                   <div className={'filter-item filter-item--inland-ferries' + (inlandFerries ? ' checked' : '') + (disableFeatures ? ' disabled' : '')}>
@@ -331,21 +362,27 @@ export default function Filters(props) {
                       id="filter--inland-ferries"
                       onChange={e => {
                         trackEvent('click', 'map', 'Toggle inland ferries layer')
-                        setLayerVisibility('inlandFerries', !inlandFerries); 
+                        setLayerVisibility('inlandFerries', !inlandFerries);
                         setInlandFerries(!inlandFerries)
                       }}
                       defaultChecked={mapContext.visible_layers.inlandFerries}
                       disabled={disableFeatures}
                     />
+
                     <label htmlFor="filter--inland-ferries">
                       <span className="filter-item__icon">
                         <FontAwesomeIcon icon={faFerry} alt="inland ferries" />
                       </span>
                       Inland Ferries
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipInlandferries}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.ferries &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
 
                   <div className={'filter-item filter-item--weather' + (weather ? ' checked' : '') + (disableFeatures ? ' disabled' : '')}>
@@ -360,18 +397,24 @@ export default function Filters(props) {
                         setWeather(!weather)}
                       }
                       defaultChecked={mapContext.visible_layers.weather}
-                      disabled={disableFeatures}
-                    />
+                      disabled={disableFeatures} />
+
                     <label htmlFor="filter--weather">
                       <span className="filter-item__icon">
                         <FontAwesomeIcon icon={faSunCloud} alt="weather" />
                       </span>
                       Weather
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipWeather}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.weathers &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
+
                   <div className={'filter-item filter-item--rest-stops' + (restStops ? ' checked' : '') + (disableFeatures ? ' disabled' : '')}>
                     <input
                       type="checkbox"
@@ -383,7 +426,7 @@ export default function Filters(props) {
                           setLayerVisibility('largeRestStops', false);
                           setLargeRestStops(false);
                         }
-                        setLayerVisibility('restStops', !restStops); 
+                        setLayerVisibility('restStops', !restStops);
                         setRestStops(!restStops);
                       }}
                       defaultChecked={mapContext.visible_layers.restStops}
@@ -397,9 +440,14 @@ export default function Filters(props) {
                       </span>
                       Rest stops
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipRestStops}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.restStops &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
                 </div>
               </div>
@@ -420,12 +468,12 @@ export default function Filters(props) {
                           setLayerVisibility('restStops', false);
                           setRestStops(false);
                         }
-                        setLayerVisibility('largeRestStops', !largeRestStops); 
+                        setLayerVisibility('largeRestStops', !largeRestStops);
                         setLargeRestStops(!largeRestStops);
                       }}
                       defaultChecked={mapContext.visible_layers.largeRestStops}
-                      disabled={disableFeatures}
-                    />
+                      disabled={disableFeatures} />
+
                     <label htmlFor="filter--rest-stops-large-vehicle">
                       <span className="filter-item__icon">
                         <svg width="30" height="14" viewBox="0 0 30 14" fill="none" xmlns="http://www.w3.org/2000/svg" alt="large vehicle rest stops" aria-hidden="true" focusable="false" role="img">
@@ -435,9 +483,14 @@ export default function Filters(props) {
                       </span>
                       Large vehicle rest stops
                     </label>
+
                     <OverlayTrigger placement="top" overlay={tooltipRestStopsLargeVehicle}>
                       <span className="tooltip-info">?</span>
                     </OverlayTrigger>
+
+                    {loadingLayers && loadingLayers.restStops &&
+                      <Spinner animation="border" role="status" />
+                    }
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
[DBC22-2509](https://jira.th.gov.bc.ca/browse/DBC22-2509)

Simple logic despite changes in a lot of files. Key highlights:
- loadingLayers state is initialized from mapContext.visible_layers; the spinner will only be visible if the layer is enabled on load. 
- The loading function of each layers calls setState for this and sets their relative loading state to false. For styling, comment out these lines to never hide the spinner. e.g. 
`
    setLoadingLayers(prevState => ({
      ...prevState,
      cameras: false
    }));
`
- events, weathers and restStops have shared layers
