### PR TITLE
DBC22-1980: fetch advisories when map initial loading

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -52,8 +52,6 @@ import RouteSearch from '../routing/RouteSearch.js';
 import NetworkErrorPopup from './errors/NetworkError';
 import ServerErrorPopup from './errors/ServerError';
 import overrides from '../map/overrides.js';
-import { getAdvisories } from '../data/advisories.js';
-import { updateAdvisories } from '../../slices';
 
 // Map & geospatial imports
 import { applyStyle } from 'ol-mapbox-style';
@@ -439,22 +437,6 @@ export default function DriveBCMap(props) {
 
   // Advisories layer
   useEffect(() => {
-    const fetchAdvisories = async () => {
-      try {
-        const response = await getAdvisories();
-        dispatch(updateAdvisories({
-          list: response,
-          timeStamp: new Date().getTime()
-        }));
-      } catch (error) {
-        console.error('Error fetching advisories:', error);
-      }
-    };
-
-    if(!advisories){
-      fetchAdvisories();
-    }
-
     loadLayer(
       mapLayers, mapRef, mapContext,
       'advisoriesLayer', advisories, 5

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -52,6 +52,8 @@ import RouteSearch from '../routing/RouteSearch.js';
 import NetworkErrorPopup from './errors/NetworkError';
 import ServerErrorPopup from './errors/ServerError';
 import overrides from '../map/overrides.js';
+import { getAdvisories } from '../data/advisories.js';
+import { updateAdvisories } from '../../slices';
 
 // Map & geospatial imports
 import { applyStyle } from 'ol-mapbox-style';
@@ -437,6 +439,22 @@ export default function DriveBCMap(props) {
 
   // Advisories layer
   useEffect(() => {
+    const fetchAdvisories = async () => {
+      try {
+        const response = await getAdvisories();
+        dispatch(updateAdvisories({
+          list: response,
+          timeStamp: new Date().getTime()
+        }));
+      } catch (error) {
+        console.error('Error fetching advisories:', error);
+      }
+    };
+
+    if(!advisories){
+      fetchAdvisories();
+    }
+
     loadLayer(
       mapLayers, mapRef, mapContext,
       'advisoriesLayer', advisories, 5

--- a/src/frontend/src/Components/map/MapWrapper.js
+++ b/src/frontend/src/Components/map/MapWrapper.js
@@ -80,7 +80,7 @@ export default function MapWrapper(props) {
       dataLoaders.loadCurrentWeather(null, currentWeather, filteredCurrentWeathers, currentWeatherFilterPoints, dispatch, displayError);
       dataLoaders.loadRegionalWeather(null, regionalWeather, filteredRegionalWeathers, regionalWeatherFilterPoints, dispatch, displayError);
       dataLoaders.loadRestStops(null, restStops, filteredRestStops, restStopFilterPoints, dispatch, displayError);
-      dataLoaders.loadAdvisories(advisories, dispatch, displayError);
+      dataLoaders.loadAdvisories(null, advisories, filteredAdvisories, advisoryFilterPoints, dispatch, displayError);
     }
   };
 


### PR DESCRIPTION
This PR fixed the issue that AdvisoriesWidget does not showing up when the map refreshed. 
The fix will fetch advisories when map the is initial loaded.

Jira: https://jira.th.gov.bc.ca/browse/DBC22-1980