### PR TITLE
DBC22-2557: show alert longer when removing cameras for saved cameras…

### DIFF
--- a/src/frontend/src/Components/cameras/CameraCard.js
+++ b/src/frontend/src/Components/cameras/CameraCard.js
@@ -35,7 +35,8 @@ import trackEvent from '../shared/TrackEvent.js';
 
 export default function CameraCard(props) {
   /* Setup */
-  const { cameraData } = props;
+  const { cameraData, onShowAlertChange } = props;
+  // const { cameraData } = props;
   const location = useLocation();
 
   const { authContext } = useContext(AuthContext);
@@ -78,6 +79,7 @@ export default function CameraCard(props) {
     // Set new close alert timer to reference
     timeout.current = setTimeout(() => {
       setShowAlert(false);
+      // onShowAlertChange(false);
     }, 5000);
   }, [isRemoving]);
 
@@ -141,6 +143,7 @@ export default function CameraCard(props) {
     const id = location.pathname == '/my-cameras' ? camId : camera.id;
     deleteFavoriteCamera(id, dispatch, removeFavCam);
     setIsRemoving(true);
+    onShowAlertChange(true);
   }
 
   function handleChildClick(e) {

--- a/src/frontend/src/Components/cameras/CameraList.js
+++ b/src/frontend/src/Components/cameras/CameraList.js
@@ -12,7 +12,7 @@ import './CameraList.scss';
 
 export default function CameraList(props) {
   // Props
-  const { cameras, getCheckedHighway } = props;
+  const { cameras, getCheckedHighway, onShowAlertChange } = props;
 
   // Contexts
   const { camsContext } = useContext(CamsContext);
@@ -63,7 +63,7 @@ export default function CameraList(props) {
     const groups = [];
 
     for (const {highway, cams} of groupedCams) {
-      groups.push(<HighwayGroup key={highway} highway={highway} cams={cams} />);
+      groups.push(<HighwayGroup key={highway} highway={highway} cams={cams} onShowAlertChange={onShowAlertChange}/>);
     }
 
     return groups;

--- a/src/frontend/src/Components/cameras/HighwayGroup.js
+++ b/src/frontend/src/Components/cameras/HighwayGroup.js
@@ -7,7 +7,7 @@ import highwayShield from './highwayShield';
 
 export default function HighwayGroup(props) {
   // Props
-  const { highway, cams } = props;
+  const { highway, cams, onShowAlertChange } = props;
 
   return (
     <div className="highway-group">
@@ -31,7 +31,7 @@ export default function HighwayGroup(props) {
 
       <div className="webcam-group">
         {cams.map((cam, id) => (
-          <CameraCard cameraData={cam} className="webcam" key={id} />
+          <CameraCard cameraData={cam} className="webcam" key={id} onShowAlertChange={onShowAlertChange}/>
         ))}
       </div>
     </div>

--- a/src/frontend/src/pages/CamerasListPage.js
+++ b/src/frontend/src/pages/CamerasListPage.js
@@ -343,7 +343,7 @@ export default function CamerasListPage() {
               )}
             </div>
 
-            <CameraList cameras={ displayedCameras ? displayedCameras : [] } getCheckedHighway={getCheckedHighway}></CameraList>
+            <CameraList cameras={ displayedCameras ? displayedCameras : [] } getCheckedHighway={getCheckedHighway} onShowAlertChange={(()=>{})}></CameraList>
 
             {!(displayedCameras && displayedCameras.length) &&
               <div className="empty-cam-display">

--- a/src/frontend/src/pages/SavedCamerasPage.js
+++ b/src/frontend/src/pages/SavedCamerasPage.js
@@ -20,6 +20,7 @@ import ServerErrorPopup from '../Components//map/errors/ServerError';
 import CameraList from '../Components/cameras/CameraList';
 import Footer from '../Footer';
 import PageHeader from '../PageHeader';
+import Alert from '../Components/shared/Alert';
 
 // Styling
 import './SavedCamerasPage.scss';
@@ -39,11 +40,13 @@ export default function SavedCamerasPage() {
 
   // UseRef hooks
   const isInitialMount = useRef(true);
+  const timeout = useRef();
 
   // UseState hooks
   const [processedCameras, setProcessedCameras] = useState(null);
   const [showNetworkError, setShowNetworkError] = useState(false);
   const [showServerError, setShowServerError] = useState(false);
+  const [alertStatus, setAlertStatus] = useState(false);
 
   // Error handling
   const displayError = (error) => {
@@ -88,6 +91,18 @@ export default function SavedCamerasPage() {
     }
   };
 
+  const handleShowAlertChange = (value) => {
+    setAlertStatus(value);
+    console.log('Alert status updated:', value);
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+    }
+    timeout.current = setTimeout(() => {
+      setAlertStatus(false);
+    }, 5000);
+
+  };
+
   // useEffect hooks
   // Redirect to login page if user is not logged in
   useEffect(() => {
@@ -113,6 +128,10 @@ export default function SavedCamerasPage() {
     getSavedCameras();
   }, [favCams]);
 
+  const getAlertMessage = () => {
+    return <p>{'Removed from '} <a href="/my-cameras">My cameras</a></p>;
+  };
+
   // Rendering
   return (
     <div className="saved-cameras-page">
@@ -133,6 +152,7 @@ export default function SavedCamerasPage() {
         <CameraList
           cameras={ processedCameras ? processedCameras : [] }
           getCheckedHighway={()=>{}}
+          onShowAlertChange={handleShowAlertChange}
         />
 
         {!(processedCameras && processedCameras.length) &&
@@ -144,6 +164,7 @@ export default function SavedCamerasPage() {
             </p>
           </div>
         }
+        <Alert showAlert={alertStatus} setShowAlert={setAlertStatus} message={getAlertMessage()} />
       </Container>
 
       <Footer />


### PR DESCRIPTION
DBC22-2557: show alert longer when removing cameras for saved cameras page

This PR is to fixed the issue that removing alert is not shown long enough to the user to read. 
Basically, this issue happened when a camera was removed on saved cameras page, which was caused by the CameraCard was removed from its parent when delete api was called. The reason that the alert is not shown long enough is that the parents of the alert component does not exist anymore.

The solution is to add another <Alert> in <SavedCamerasPage>, and pass in a callback function to check if a the alert should be shown or should be turned off. So the alert will be shown even when the child <CameraCard> was removed.

Jira: https://jira.th.gov.bc.ca/browse/DBC22-2557
 