### PR TITLE
DBC22-1321: Add new parameter to Geocoder query

### DIFF
--- a/src/frontend/src/Components/data/locations.js
+++ b/src/frontend/src/Components/data/locations.js
@@ -8,7 +8,8 @@ export function getLocations(addressInput) {
       brief: true,
       autoComplete: true,
       addressString: addressInput,
-      locationDescriptor: 'routingPoint' 
+      locationDescriptor: 'routingPoint', 
+      exactSpelling: true
     }, {
       'apiKey': `${window.GEOCODER_API_AUTH_KEY}`,
     }


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-1321
This adds a new query parameter called exactSpelling which fixes a lot of issues we had with the geocoder. Currently only works in their test environments, but I've pointed our dev environment there for testing.
Change is backwards compatible, meaning we can use this new parameter and it will not break when using the current prod URL.
They are completing their testing cycle on Tues Aug 27th and will move it to prod thereafter.