### PR TITLE
DBC22-2613: Changed click action in Event cards on mobile

### DIFF
--- a/src/frontend/src/Components/events/EventCard.js
+++ b/src/frontend/src/Components/events/EventCard.js
@@ -17,7 +17,7 @@ import './EventCard.scss';
 
 export default function EventCard(props) {
   // Props
-  const { event, showLoader } = props;
+  const { event, showLoader, handleRoute } = props;
 
   // Rendering
   return (
@@ -73,7 +73,12 @@ export default function EventCard(props) {
             <button
               className="viewMap-btn"
               aria-label="View on map"
-              onClick={() => console.log('click')}>
+              onClick={() => handleRoute(event)}
+              onKeyDown={(keyEvent) => {
+                if (keyEvent.keyCode == 13) {
+                  handleRoute(event);
+                }
+              }}>
               <FontAwesomeIcon icon={faLocationDot} />
               <span>View on map</span>
             </button> }

--- a/src/frontend/src/Components/events/EventCard.scss
+++ b/src/frontend/src/Components/events/EventCard.scss
@@ -34,6 +34,8 @@
         border-top: 1px solid $Divider;
         padding: 8px;
         flex-grow: 1;
+        display: flex;
+        align-items: center;
       }
 
       &.map, &.location {

--- a/src/frontend/src/pages/EventsListPage.js
+++ b/src/frontend/src/pages/EventsListPage.js
@@ -397,19 +397,11 @@ export default function EventsListPage() {
                 <div className="events-list">
                   { !showLoader && processedEvents.map(
                     (e) => (
-                      <div className="card-selector" key={e.id}
-                        onClick={() => handleRoute(e)}
-                        onKeyDown={(keyEvent) => {
-                          if (keyEvent.keyCode == 13) {
-                            handleRoute(e);
-                          }
-                        }}>
-
-                        <EventCard
-                          className="event"
-                          event={e}
-                        />
-                      </div>
+                      <EventCard
+                        key={e.id}
+                        event={e}
+                        handleRoute={handleRoute}
+                      />
                     ),
                   )}
 

--- a/src/frontend/src/pages/EventsListPage.scss
+++ b/src/frontend/src/pages/EventsListPage.scss
@@ -21,10 +21,6 @@
     }
   }
 
-  .card-selector{
-    cursor: pointer;
-  }
-
   .controls-container {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Changed click action in Event cards on mobile as the design changed.

Used to be the whole event card being clickable, to now, the design has added an explicit link to "View on map" so the click action has been moved accordingly to that button/link.