### PR TITLE
DBC22-2667: Add noindex header for non-prod

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -63,6 +63,7 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Permissions-Policy "geolocation=(self), fullscreen=*";
     add_header X-Content-Type-Options "nosniff";
+    add_header X-Robots-Tag "noindex";
     
     # Add Content Security Policy header
     add_header Content-Security-Policy "default-src 'self' https://*.arcgis.com https://*.gov.bc.ca https://*.drivebc.ca data:; script-src 'self' https://*.gov.bc.ca https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/; frame-ancestors 'self'; form-action 'self' *.gov.bc.ca/ https://*.drivebc.ca";

--- a/compose/frontend/entrypoint
+++ b/compose/frontend/entrypoint
@@ -28,6 +28,14 @@ echo -e "window.SURVEY_LINK='${REACT_APP_SURVEY_LINK}';" >> $MAIN
 # Set the environment to be used for caching django content
 sed -i "s~{ENVIRONMENT}~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
 
+# Check if the environment is 'prod' so that we remove the noindex header
+if [ "$ENVIRONMENT" = "prod" ]; then
+    echo "Environment is 'prod' removing X-Robots-Tag noindex header."
+    sed -i '/add_header X-Robots-Tag "noindex";/d' /etc/nginx/conf.d/default.conf
+else
+    echo "Environment is not 'prod', keeping X-Robots-Tag noindex header."
+fi
+
 #precompress the main js and css files to improve performance
 gzip -k $MAIN
 gzip -k $MAINCSS


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-2667
I added the header on default.conf and then in entrypoint file I remove it for the prod environment. I did the script in on my PC to confirm it does indeed remove the line for prod.

Once merged and deployed to test we can have Google re-scan the dev/test sites