### PR TITLE
DBC22-2592: fixed highway filter does not show non highway cameras

### DIFF
--- a/src/frontend/src/Components/cameras/CameraList.js
+++ b/src/frontend/src/Components/cameras/CameraList.js
@@ -26,7 +26,7 @@ export default function CameraList(props) {
     const checkedHighway = getCheckedHighway();
     let filteredCameras = cameras;
     if(checkedHighway){
-      filteredCameras = cameras.filter((camera) => camera.highway === checkedHighway)
+      filteredCameras = cameras.filter((camera) => (camera.highway === checkedHighway || camera.highway_display === checkedHighway))
     }
     if (!length) { camsContext.displayLength += 4; }
     const shown = filteredCameras.slice(0, length ? length : camsContext.displayLength);


### PR DESCRIPTION
DBC22-2592: fixed highway filter does not show non highway cameras

The root cause of this issue is the filter filtering out highway based on the camera "highway" property, but this property is always "0" for non highways. The fix uses another "highway_display" property to filter out non highways.

Jira: https://jira.th.gov.bc.ca/browse/DBC22-2592