### PR TITLE
DBC22-2667: Update to Github Actions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,6 +4,8 @@ name: 1. Build & Deploy to Dev
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+    - '.github/**'
   workflow_dispatch:
 
 env:
@@ -46,16 +48,6 @@ jobs:
         username: ${{ env.REGISTRY_USER }}
         password: ${{ env.REGISTRY_PASSWORD }}
 
-# Backup to handle scenarios where Github packages is down. Confluence has documentation on switching the source. 
-    - name: Push to OpenShift ImageStream
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
-        registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
-        username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
-        password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
-
   build-backend:
     runs-on: ubuntu-latest
     name: Build & Push Backend Image
@@ -86,15 +78,6 @@ jobs:
         username: ${{ env.REGISTRY_USER }}
         password: ${{ env.REGISTRY_PASSWORD }}
 
-# Backup to handle scenarios where Github packages is down. Confluence has documentation on switching the source. 
-    - name: Push to OpenShift ImageStream
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
-        registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
-        username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
-        password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
 
   build-redis:
     runs-on: ubuntu-latest
@@ -124,15 +107,6 @@ jobs:
         username: ${{ env.REGISTRY_USER }}
         password: ${{ env.REGISTRY_PASSWORD }}
 
-# Backup to handle scenarios where Github packages is down. Confluence has documentation on switching the source. 
-    - name: Push to OpenShift ImageStream
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
-        registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
-        username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
-        password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
 
   build-openshiftjobs:
     runs-on: ubuntu-latest
@@ -164,15 +138,6 @@ jobs:
         username: ${{ env.REGISTRY_USER }}
         password: ${{ env.REGISTRY_PASSWORD }}
 
-# Backup to handle scenarios where Github packages is down. Confluence has documentation on switching the source. 
-    - name: Push to OpenShift ImageStream
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
-        registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
-        username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
-        password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
 
   versionUpdate:
     needs: [build-static, build-backend, build-redis, build-openshiftjobs]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-test
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-test
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
@@ -178,7 +178,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-test
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
@@ -219,7 +219,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-test
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -95,7 +95,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-uat ${{ needs.tag.outputs.tag }}
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-uat ${{ needs.tag.outputs.tag }}
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
@@ -179,7 +179,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-uat ${{ needs.tag.outputs.tag }}
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}
@@ -221,7 +221,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build_image.outputs.image }}
-        tags: ${{ steps.build_image.outputs.tags }}
+        tags: latest latest-uat ${{ needs.tag.outputs.tag }}
         registry: ${{ vars.OPENSHIFT_IMAGESTREAM_URL }}
         username: ${{ secrets.OPENSHIFT_IMAGESTREAM_USERNAME }}
         password: ${{ secrets.OPENSHIFT_IMAGESTREAM_TOKEN }}


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-2679
I setup imagestreams as a backup in case we are having issues getting images from github, however since all images were going there we were using an excessive amount of space.
This update stops dev from pushing to openshift imagestream, limits test to push only to latest and latest-test tags, and updates UAT to push to latest latest-uat and the release tag. 