### PR TITLE
DBC22-2670: Update CSP to allow Flickr/Youtube

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -66,7 +66,7 @@ server {
     add_header X-Robots-Tag "noindex";
     
     # Add Content Security Policy header
-    add_header Content-Security-Policy "default-src 'self' https://*.arcgis.com https://*.gov.bc.ca https://*.drivebc.ca data:; script-src 'self' https://*.gov.bc.ca https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/; frame-ancestors 'self'; form-action 'self' *.gov.bc.ca/ https://*.drivebc.ca";
+    add_header Content-Security-Policy "default-src 'self' https://*.arcgis.com https://*.gov.bc.ca https://*.drivebc.ca data: https://*.flickr.com https://*.staticflickr.com https://www.youtube.com https://*.ytimg.com; script-src 'self' https://*.gov.bc.ca https://*.flickr.com https://*.staticflickr.com 'unsafe-inline'; style-src 'self' https://*.flickr.com https://*.staticflickr.com 'unsafe-inline'; frame-ancestors 'self'; form-action 'self' *.gov.bc.ca/ https://*.drivebc.ca";
 
     server_tokens off;
 


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-2670
CSP change to add flickr and youtube. Unfortunately I needed to add 'unsafe-inline' to style and scripts due to how Flickr does the embed. This will cause a Medium issue in the ZAP scan from a quick test I did.