### PR TITLE
DBC22-2465: unread display for advisories/bulletins

### DIFF
--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -49,6 +49,7 @@ config.autoAddCss = false
 export const AlertContext = createContext();
 export const AuthContext = createContext(null);
 export const CamsContext = createContext(null);
+export const CMSContext = createContext();
 export const MapContext = createContext(null);
 
 let callingSession = false;
@@ -66,6 +67,7 @@ function App() {
   const [alertMessage, setAlertMessage] = useState();
   const [authContext, setAuthContext] = useState(getInitialAuthContext());
   const [camsContext, setCamsContext] = useState({ displayLength: 21, setDisplayLength: (length) => {} });
+  const [cmsContext, setCMSContext] = useState(getInitialCMSContext());
   const [mapContext, setMapContext] = useState(getInitialMapContext());
 
   // Effects
@@ -104,6 +106,14 @@ function App() {
 
   /* Helpers */
   // Data functions
+  function getInitialCMSContext() {
+    const context = localStorage.getItem('cmsContext');
+    return context ? JSON.parse(context) : {
+      readAdvisories: [],
+      readBulletins: []
+    };
+  }
+
   function getInitialMapContext() {
     const context = localStorage.getItem('mapContext');
     return context ? JSON.parse(context) : {
@@ -170,35 +180,37 @@ function App() {
       <MapContext.Provider value={{ mapContext, setMapContext }}>
         <CamsContext.Provider value={{ camsContext, setCamsContext }}>
           <AlertContext.Provider value={{ alertMessage, setAlertMessage }}>
-            <div className="App">
-              <Header />
+            <CMSContext.Provider value={{ cmsContext, setCMSContext }}>
+              <div className="App">
+                <Header />
 
-              <ScrollToTop />
+                <ScrollToTop />
 
-              <Routes>
-                <Route path="/" element={<MapPage />} />
-                <Route path="/my-cameras" element={<SavedCamerasPage />} />
-                <Route path="/my-routes" element={<SavedRoutesPage />} />
-                <Route path="/cameras" element={<CamerasListPage />} />
-                <Route path="/cameras/:id" element={<CameraDetailsPage />} />
-                <Route path="/delays" element={<EventsListPage />} />
-                <Route path="/advisories" element={<AdvisoriesListPage />} />
-                <Route path="/advisories/:id" element={<AdvisoryDetailsPage />} />
-                <Route path="/bulletins" element={<BulletinsListPage />} />
-                <Route path="/bulletins/:id" element={<BulletinDetailsPage />} />
-                <Route path="/account" element={<AccountPage />} />
-                {/* Catch-all route for 404 errors */}
-                <Route path="*" element={<NotFoundPage />} />
-                <Route path="/problems" element={<ProblemsPage />} />
-                <Route path="/website-problem" element={<div>Website Problem or Suggestion Page</div>} />
-                <Route path="/highway-problem" element={<ReportRoadPage />} />
-                <Route path="/road-electrical-problem" element={<ReportElectricalPage />} />
-              </Routes>
+                <Routes>
+                  <Route path="/" element={<MapPage />} />
+                  <Route path="/my-cameras" element={<SavedCamerasPage />} />
+                  <Route path="/my-routes" element={<SavedRoutesPage />} />
+                  <Route path="/cameras" element={<CamerasListPage />} />
+                  <Route path="/cameras/:id" element={<CameraDetailsPage />} />
+                  <Route path="/delays" element={<EventsListPage />} />
+                  <Route path="/advisories" element={<AdvisoriesListPage />} />
+                  <Route path="/advisories/:id" element={<AdvisoryDetailsPage />} />
+                  <Route path="/bulletins" element={<BulletinsListPage />} />
+                  <Route path="/bulletins/:id" element={<BulletinDetailsPage />} />
+                  <Route path="/account" element={<AccountPage />} />
+                  {/* Catch-all route for 404 errors */}
+                  <Route path="*" element={<NotFoundPage />} />
+                  <Route path="/problems" element={<ProblemsPage />} />
+                  <Route path="/website-problem" element={<div>Website Problem or Suggestion Page</div>} />
+                  <Route path="/highway-problem" element={<ReportRoadPage />} />
+                  <Route path="/road-electrical-problem" element={<ReportElectricalPage />} />
+                </Routes>
 
-              <Modal />
+                <Modal />
 
-              <Alert alertMessage={alertMessage} closeAlert={() => setAlertMessage(null)} />
-            </div>
+                <Alert alertMessage={alertMessage} closeAlert={() => setAlertMessage(null)} />
+              </div>
+            </CMSContext.Provider>
           </AlertContext.Provider>
         </CamsContext.Provider>
       </MapContext.Provider>

--- a/src/frontend/src/Components/advisories/AdvisoriesList.js
+++ b/src/frontend/src/Components/advisories/AdvisoriesList.js
@@ -1,27 +1,42 @@
 // React
-import React from 'react';
+import React, { useContext } from 'react';
 
-// Components and functions
-import { stripRichText } from '../data/helper';
-import FriendlyTime from '../shared/FriendlyTime';
-import trackEvent from '../shared/TrackEvent.js';
+// Navigation
+import { useNavigate } from 'react-router-dom';
 
-// Third party packages
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+// External imports
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faChevronRight
 } from '@fortawesome/pro-solid-svg-icons';
 
+// Internal imports
+import { CMSContext } from '../../App';
+import { stripRichText } from '../data/helper';
+import FriendlyTime from '../shared/FriendlyTime';
+import trackEvent from '../shared/TrackEvent.js';
+
 // Styling
 import './AdvisoriesList.scss';
 
-
 export default function AdvisoriesList(props) {
-  // State, props and context
+  /* Setup */
+  // Context
+  const { cmsContext } = useContext(CMSContext);
+
+  // Navigation
+  const navigate = useNavigate();
+
+  // Props
   const { advisories, showDescription, showTimestamp, showPublished, showArrow, isAdvisoriesListPage } = props;
 
-  function handleClick(advisory) {
+  function handleClick(advisory, keyEvent) {
+    if (keyEvent && keyEvent.keyCode != 13 && keyEvent.keyCode != 32) {
+      return;
+    }
+
     trackEvent('click', 'advisories-list', 'Advisory', advisory.title, advisory.teaser);
+    navigate(`/advisories/${advisory.id}`);
   }
 
   // Rendering
@@ -30,15 +45,23 @@ export default function AdvisoriesList(props) {
       {!!advisories && advisories.map((advisory, index) => {
         if (isAdvisoriesListPage) {
           return (
-            <div className="advisory-li unread" key={advisory.id}>
+            <div className="advisory-li" key={advisory.id}>
               <div className="advisory-li__content">
                 <div className="advisory-li__content__partition advisory-li-title-container">
-                  <a className="advisory-li-title" href={`/advisories/${advisory.id}`}>{advisory.title}</a>
+                  <a className="advisory-li-title"
+                    href="#"
+                    onClick={() => handleClick(advisory)}
+                    onKeyDown={(keyEvent) => handleClick(advisory, keyEvent)}>
+
+                    {advisory.title}
+                  </a>
+
                   <div className="timestamp-container">
                     <span className="advisory-li-state">{advisory.first_published_at != advisory.last_published_at ? "Updated" : "Published" }</span>
                     <FriendlyTime date={advisory.latest_revision_created_at} />
                   </div>
                 </div>
+
                 <div className='advisory-li__content__partition advisory-li-body-container'>
                   {advisory.teaser &&
                     <div className='advisory-li-body'>{advisory.teaser}</div>
@@ -48,14 +71,19 @@ export default function AdvisoriesList(props) {
                     <div className='advisory-li-body'>{stripRichText(advisory.body)}</div>
                   }
                 </div>
+
                 <div className="advisory-li__content__partition timestamp-container timestamp-container--mobile">
                   <span className="advisory-li-state">{advisory.first_published_at != advisory.last_published_at ? "Updated" : "Published" }</span>
                   <FriendlyTime date={advisory.latest_revision_created_at} />
                 </div>
+
                 <div className="button-container">
                   <a className="viewDetails-link"
-                    href={`/advisories/${advisory.id}`}
+                    href="#"
+                    onClick={() => handleClick(advisory)}
+                    onKeyDown={(keyEvent) => handleClick(advisory, keyEvent)}
                     aria-label={`View advisory details for ${advisory.title}`}>
+
                     View details
                     <FontAwesomeIcon icon={faChevronRight} />
                   </a>
@@ -63,28 +91,32 @@ export default function AdvisoriesList(props) {
               </div>
             </div>
           );
-        }
-        else {
+
+        } else {
           return (
-            <a className="advisory-li unread" key={advisory.id} href={`/advisories/${advisory.id}`} onClick={() => handleClick(advisory)}
-              onKeyDown={(keyEvent) => {
-                if (keyEvent.keyCode == 13) {
-                  handleClick(advisory);
-                }
-              }}>
+            <a className={`advisory-li ${!cmsContext.readAdvisories.includes(advisory.id) ? 'unread' : ''}`}
+              key={advisory.id}
+              href="#"
+              onClick={() => handleClick(advisory)}
+              onKeyDown={(keyEvent) => handleClick(advisory, keyEvent)}>
+
               <div className="advisory-li__content" tabIndex={0}>
                 <div className="advisory-li-title-container">
                   <p className='advisory-li-title'>{advisory.title}</p>
+
                   {(showTimestamp && showPublished) &&
-                  <div className="timestamp-container">
-                    <span className="advisory-li-state">{advisory.first_published_at != advisory.last_published_at ? "Updated" : "Published" }</span>
-                    <FriendlyTime date={advisory.latest_revision_created_at} />
-                  </div>
+                    <div className="timestamp-container">
+                      {!cmsContext.readAdvisories.includes(advisory.id) && <div className="unread-display"></div>}
+                      <span className="advisory-li-state">{advisory.first_published_at != advisory.last_published_at ? "Updated" : "Published" }</span>
+                      <FriendlyTime date={advisory.latest_revision_created_at} />
+                    </div>
                   }
+
                   {(showTimestamp && !showPublished) &&
-                  <div className="timestamp-container">
-                    <FriendlyTime date={advisory.latest_revision_created_at} />
-                  </div>
+                    <div className="timestamp-container">
+                      {!cmsContext.readAdvisories.includes(advisory.id) && <div className="unread-display"></div>}
+                      <FriendlyTime date={advisory.latest_revision_created_at} />
+                    </div>
                   }
                 </div>
 

--- a/src/frontend/src/Components/advisories/AdvisoriesList.scss
+++ b/src/frontend/src/Components/advisories/AdvisoriesList.scss
@@ -48,6 +48,7 @@
 
   .timestamp-container {
     display: flex;
+    align-items: center;
 
     .advisory-li-state, .friendly-time, .formatted-date {
       margin-left: 0.5ch;
@@ -61,6 +62,15 @@
       color: $Grey70;
       font-size: 0.875rem;
       line-height: 1.5;
+    }
+
+    .unread-display {
+      height: 8px;
+      width: 8px;
+      background-color: #CE3E39;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 5px;
     }
   }
 

--- a/src/frontend/src/Components/bulletins/BulletinsList.js
+++ b/src/frontend/src/Components/bulletins/BulletinsList.js
@@ -21,7 +21,7 @@ export default function Bulletins(props) {
 
   function handleClick(bulletin) {
     trackEvent('click', 'bulletins-list', 'Bulletin', bulletin.title, bulletin.teaser);
-     navigate(`/bulletins/${bulletin.id}`);
+    navigate(`/bulletins/${bulletin.id}`);
   }
 
   // Rendering

--- a/src/frontend/src/Components/bulletins/BulletinsList.js
+++ b/src/frontend/src/Components/bulletins/BulletinsList.js
@@ -1,11 +1,14 @@
 // React
 import React from 'react';
-import {useNavigate} from 'react-router-dom';
 
-// Components and functions
+// Navigation
+import { useNavigate } from 'react-router-dom';
+
+// Internal imports
 import { stripRichText } from '../data/helper';
 import FriendlyTime from '../shared/FriendlyTime';
 import trackEvent from '../shared/TrackEvent';
+
 // Styling
 import './BulletinsList.scss';
 
@@ -29,7 +32,7 @@ export default function Bulletins(props) {
     <ul className='bulletins-list'>
       {!!bulletins && bulletins.map((bulletin, index) => {
         return (
-          <li className='bulletin-li unread' key={bulletin.id} onClick={() => handleClick(bulletin)}
+          <li className='bulletin-li' key={bulletin.id} onClick={() => handleClick(bulletin)}
             onKeyDown={(keyEvent) => {
               if (keyEvent.keyCode == 13) {
                 handleClick(bulletin);
@@ -52,6 +55,7 @@ export default function Bulletins(props) {
                 <FriendlyTime date={bulletin.latest_revision_created_at} />
               </div>
             </div>
+
             <div className='bulletin-li-thumbnail-container'>
               <div className={bulletin.image_url ? 'bulletin-li-thumbnail' : 'bulletin-li-thumbnail-default'}>
                 <img className='thumbnail-logo' src={bulletin.image_url ? bulletin.image_url : logo} alt={bulletin.image_alt_text} />

--- a/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
+++ b/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
@@ -15,12 +15,17 @@ import AdvisoriesList from '../../advisories/AdvisoriesList';
 import './AdvisoriesPanel.scss';
 
 export default function AdvisoriesPanel(props) {
-  const { advisories } = props;
+  const { advisories, openAdvisoriesOverlay } = props;
 
   // Context
   const { cmsContext, setCMSContext } = useContext(CMSContext);
 
   useEffect(() => {
+    // Do not update context if the overlay is not open
+    if (openAdvisoriesOverlay === false) {
+      return;
+    }
+
     const advisoriesIds = advisories.map(advisory => advisory.id);
 
     // Combine and remove duplicates
@@ -29,7 +34,7 @@ export default function AdvisoriesPanel(props) {
 
     setCMSContext(updatedContext);
     localStorage.setItem('cmsContext', JSON.stringify(updatedContext));
-  }, [advisories]);
+  }, [advisories, openAdvisoriesOverlay]);
 
   return (
     <div className="popup popup--advisories" tabIndex={0}>

--- a/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
+++ b/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
@@ -1,11 +1,14 @@
 // React
-import React, { useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 
-// Third party packages
+// External imports
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faFlag
 } from '@fortawesome/pro-solid-svg-icons';
+
+// Internal imports
+import { CMSContext } from '../../../App';
 import AdvisoriesList from '../../advisories/AdvisoriesList';
 
 // Styling
@@ -14,8 +17,19 @@ import './AdvisoriesPanel.scss';
 export default function AdvisoriesPanel(props) {
   const { advisories } = props;
 
-  // Intentionally using useState to avoid modifying the original array
-  const [advisoriesDisplay] = useState(advisories);
+  // Context
+  const { cmsContext, setCMSContext } = useContext(CMSContext);
+
+  useEffect(() => {
+    const advisoriesIds = advisories.map(advisory => advisory.id);
+
+    // Combine and remove duplicates
+    const readAdvisories = Array.from(new Set([...advisoriesIds, ...cmsContext.readAdvisories]));
+    const updatedContext = {...cmsContext, readAdvisories: readAdvisories};
+
+    setCMSContext(updatedContext);
+    localStorage.setItem('cmsContext', JSON.stringify(updatedContext));
+  }, [advisories]);
 
   return (
     <div className="popup popup--advisories" tabIndex={0}>
@@ -26,7 +40,7 @@ export default function AdvisoriesPanel(props) {
         <p className="name">Advisories</p>
       </div>
       <div className="popup__content">
-        <AdvisoriesList advisories={advisoriesDisplay} showDescription={false} showTimestamp={true} showArrow={true} />
+        <AdvisoriesList advisories={advisories} showDescription={false} showTimestamp={true} showArrow={true} />
       </div>
     </div>
   );

--- a/src/frontend/src/Components/shared/header/Header.scss
+++ b/src/frontend/src/Components/shared/header/Header.scss
@@ -98,6 +98,8 @@
 				padding: 10px 12px;
 				border: transparent solid 2px;
 				cursor: pointer;
+				display: flex;
+				align-items: center;
 
 				@media (min-width: 992px) {
 					padding: 15px;
@@ -117,18 +119,18 @@
 					border-bottom: rgb(46, 93, 215) solid 2px;
 				}
 
-				// styling for unread notification badge for Advisories and Bulletins
-				// &:after {
-				// 	content: '1';
-				// 	font-size: 10px;
-				// 	font-weight: 700;
-				// 	padding: 1px 8px;
-				// 	color: white;
-				// 	background-color: $BC-Blue;
-				// 	border-radius: 8px;
-				// 	margin-left: 8px;
-				// 	vertical-align: middle;
-				// }
+				.unread-count {
+					font-size: 10px;
+					font-weight: 700;
+					padding: 0 9px;
+					color: white;
+					background-color: $BC-Blue;
+					border-radius: 12px;
+					margin-left: 8px;
+					display: flex;
+					align-items: center;
+					height: 20px;
+				}
 			}
 		}
 	}

--- a/src/frontend/src/pages/BulletinDetailsPage.js
+++ b/src/frontend/src/pages/BulletinDetailsPage.js
@@ -1,12 +1,15 @@
 // React
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+
+// Navigation
 import { useParams } from 'react-router-dom';
 
-// Third party packages
+// External imports
 import Container from 'react-bootstrap/Container';
 import parse from 'html-react-parser';
 
-// Components and functions
+// Internal imports
+import { CMSContext } from '../App';
 import { getBulletins } from '../Components/data/bulletins.js';
 import { NetworkError, ServerError } from '../Components/data/helper';
 import NetworkErrorPopup from '../Components//map/errors/NetworkError';
@@ -18,11 +21,14 @@ import FriendlyTime from '../Components/shared/FriendlyTime';
 import './BulletinDetailsPage.scss';
 
 export default function BulletinDetailsPage() {
-  // Context and router data
+  /* Setup */
+  // Navigation
   const params = useParams();
-  const isInitialMount = useRef(true);
 
-  // UseState hooks
+  // Context
+  const { cmsContext, setCMSContext } = useContext(CMSContext);
+
+  // States
   const [bulletin, setBulletin] = useState(null);
   const [showNetworkError, setShowNetworkError] = useState(false);
   const [showServerError, setShowServerError] = useState(false);
@@ -41,9 +47,15 @@ export default function BulletinDetailsPage() {
   const loadBulletin = async () => {
     const bulletinData = await getBulletins(params.id).catch((error) => displayError(error));
     setBulletin(bulletinData);
-    isInitialMount.current = false;
 
     document.title = `DriveBC - Bulletins - ${bulletinData.title}`;
+
+    // Combine and remove duplicates
+    const readBulletins = Array.from(new Set([...cmsContext.readBulletins, bulletinData.id]));
+    const updatedContext = {...cmsContext, readBulletins: readBulletins};
+
+    setCMSContext(updatedContext);
+    localStorage.setItem('cmsContext', JSON.stringify(updatedContext));
   };
 
   useEffect(() => {

--- a/src/frontend/src/pages/CamerasListPage.js
+++ b/src/frontend/src/pages/CamerasListPage.js
@@ -345,7 +345,7 @@ export default function CamerasListPage() {
             onClick={() => setOpenAdvisoriesOverlay(!openAdvisoriesOverlay)}>
             <FontAwesomeIcon icon={faXmark} />
           </button>
-          <AdvisoriesPanel advisories={advisories} />
+          <AdvisoriesPanel advisories={advisories} openAdvisoriesOverlay={openAdvisoriesOverlay} />
         </div>
       }
 

--- a/src/frontend/src/pages/EventsListPage.js
+++ b/src/frontend/src/pages/EventsListPage.js
@@ -446,7 +446,7 @@ export default function EventsListPage() {
             onClick={() => setOpenAdvisoriesOverlay(!openAdvisoriesOverlay)}>
             <FontAwesomeIcon icon={faXmark} />
           </button>
-          <AdvisoriesPanel advisories={advisories} />
+          <AdvisoriesPanel advisories={advisories} openAdvisoriesOverlay={openAdvisoriesOverlay} />
         </div>
       }
 


### PR DESCRIPTION
[DBC22-2465](https://jira.th.gov.bc.ca/browse/DBC22-2465)

Note "unread" class in the list pages are no longer relevant since all advisoires/bulletins are marked as read as soon as we enter the page, per requirement from wireframes. In the same vein, advisoires in the advisory map panel will never show and unread state.