### PR TITLE
DBC22-2661: Hiding empty state message before the loading state for cameras and delays.

### DIFF
--- a/src/frontend/src/pages/CamerasListPage.js
+++ b/src/frontend/src/pages/CamerasListPage.js
@@ -319,7 +319,7 @@ export default function CamerasListPage() {
 
             <CameraList cameras={ displayedCameras ? displayedCameras : [] } showLoader={showLoader} enableHighwayFilter={true}></CameraList>
 
-            {!(displayedCameras && displayedCameras.length) &&
+            {(!showLoader && !(displayedCameras && displayedCameras.length)) &&
               <div className="empty-cam-display">
                 <h2>No cameras to display</h2>
 

--- a/src/frontend/src/pages/EventsListPage.js
+++ b/src/frontend/src/pages/EventsListPage.js
@@ -426,7 +426,7 @@ export default function EventsListPage() {
                 </div>
               }
 
-              {!processedEvents.length &&
+              {(!showLoader && !processedEvents.length) &&
                 <div className="empty-event-display">
                   <h2>No delays to display</h2>
 


### PR DESCRIPTION
[DBC22-2661](https://jira.th.gov.bc.ca/browse/DBC22-2661) The ticket only mentions the Camera list, but I found the same behaviour happening on the Delays page. Duplicate ticket for the Delays list might come up later.