### PR TITLE
DBC22-2654: fixed Android Chrome calculating view height incorrectly

### DIFF
--- a/src/frontend/public/index.html
+++ b/src/frontend/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content">
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"


### PR DESCRIPTION
[DBC22-2654](https://jira.th.gov.bc.ca/browse/DBC22-2654)

https://stackoverflow.com/questions/76026292/why-is-window-innerheight-incorrect-until-i-tap-chrome-android

It would be easier to let Jason test this unless you have the right setup.