### PR TITLE
DBC22-2759: Remove direct mapping to image

### DIFF
--- a/infrastructure/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/infrastructure/crunchy-postgres/templates/PostgresCluster.yaml
@@ -14,7 +14,6 @@ spec:
   {{ if .Values.postGISVersion }}
   postGISVersion: {{ .Values.postGISVersion | quote }}
   {{ end }}
-  postgresVersion: {{ .Values.postgresVersion }}
 
   {{ if .Values.pgmonitor.enabled }}
 

--- a/infrastructure/crunchy-postgres/values-dev.yaml
+++ b/infrastructure/crunchy-postgres/values-dev.yaml
@@ -1,6 +1,6 @@
 fullnameOverride: dev-drivebc
 
-crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
+#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
 
 postgresVersion: 15
 postGISVersion: '3.3'

--- a/infrastructure/crunchy-postgres/values-prod.yaml
+++ b/infrastructure/crunchy-postgres/values-prod.yaml
@@ -1,6 +1,6 @@
 fullnameOverride: prod-drivebc
 
-crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
+#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
 
 postgresVersion: 15
 postGISVersion: '3.3'

--- a/infrastructure/crunchy-postgres/values-test.yaml
+++ b/infrastructure/crunchy-postgres/values-test.yaml
@@ -1,6 +1,6 @@
 fullnameOverride: test-drivebc
 
-crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
+#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
 
 postgresVersion: 15
 postGISVersion: '3.3'

--- a/infrastructure/crunchy-postgres/values-uat.yaml
+++ b/infrastructure/crunchy-postgres/values-uat.yaml
@@ -1,6 +1,6 @@
 fullnameOverride: uat-drivebc
 
-crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
+#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0
 
 postgresVersion: 15
 postGISVersion: '3.3'


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-2759
With the upgrade to crunchy operator 5.5.1 we needed to remove the image tag from the helm chart. I manually updated the PostgresCluster object to fix this, but also made the change here so that if we need to rebuild the cluster, it's already fixed.