### PR TITLE
DBC22-2775: Add idp hint

### DIFF
--- a/src/backend/config/settings/third_party.py
+++ b/src/backend/config/settings/third_party.py
@@ -60,6 +60,9 @@ SOCIALACCOUNT_PROVIDERS = {
                 'server_url': env("BCEID_URL"),
             }
         },
+        'AUTH_PARAMS': {
+            'kc_idp_hint': 'bceidbasic',
+        },        
     }
 }
 


### PR DESCRIPTION
https://jira.th.gov.bc.ca/browse/DBC22-2775
Recent regression that removed the IDP hint. Just adding it back again so it goes directly to BCeID instead of the option page for IDIR or BCeID