### PR TITLE
DBC22-2778: updated color when friendly time hovered

### DIFF
--- a/src/frontend/src/Components/shared/FriendlyTime.scss
+++ b/src/frontend/src/Components/shared/FriendlyTime.scss
@@ -9,7 +9,7 @@
     cursor: pointer;
 
     time:hover {
-      color: $Type-Link;
+      color: $Type-Link-Time-Hover;
     }
   }
 

--- a/src/frontend/src/Components/shared/FriendlyTime.scss
+++ b/src/frontend/src/Components/shared/FriendlyTime.scss
@@ -9,7 +9,8 @@
     cursor: pointer;
 
     time:hover {
-      color: $Type-Link-Time-Hover;
+      color: $White;
+      text-decoration: underline;
     }
   }
 

--- a/src/frontend/src/styles/variables.scss
+++ b/src/frontend/src/styles/variables.scss
@@ -3,6 +3,7 @@ $Type-Primary: #292929;
 $Type-Secondary: #474543;
 $Type-Disabled: #A19F9D;
 $Type-Link: #1A5A96;
+$Type-Link-Time-Hover: #1EA0F1;
 
 //Dividers & Border
 $Divider: #D9D9D9;

--- a/src/frontend/src/styles/variables.scss
+++ b/src/frontend/src/styles/variables.scss
@@ -3,7 +3,6 @@ $Type-Primary: #292929;
 $Type-Secondary: #474543;
 $Type-Disabled: #A19F9D;
 $Type-Link: #1A5A96;
-$Type-Link-Time-Hover: #1EA0F1;
 
 //Dividers & Border
 $Divider: #D9D9D9;


### PR DESCRIPTION
DBC22-2778: updated color when friendly time hovered.
The fix updated the color hovered on friendly time of camera details page, to have a contrast ratio when hovering on black background.

Jira: https://jira.th.gov.bc.ca/browse/DBC22-2778