### PR TITLE
DBC22-2905: centered the map only for the first loading when advisories are available

### DIFF
--- a/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
+++ b/src/frontend/src/Components/map/panels/AdvisoriesPanel.js
@@ -28,14 +28,6 @@ export default function AdvisoriesPanel(props) {
       return;
     }
 
-    // Center to the geometric center of all advisories' boundaries for mobile view
-    if(smallScreen){
-      const allCoordinates = advisories
-        .map(advisory => advisory.geometry.coordinates)
-        .flat(3);
-      fitMap(allCoordinates, mapView);
-    }
-
     const advisoriesIds = advisories.map(advisory => advisory.id.toString() + '-' + advisory.live_revision.toString());
 
     // Combine and remove duplicates
@@ -44,7 +36,17 @@ export default function AdvisoriesPanel(props) {
 
     setCMSContext(updatedContext);
     localStorage.setItem('cmsContext', JSON.stringify(updatedContext));
-  }, [advisories, openAdvisoriesOverlay, smallScreen]);
+  }, [advisories, openAdvisoriesOverlay]);
+
+  useEffect(() => {
+    // Center to the geometric center of all advisories' boundaries for mobile view
+    if(smallScreen){
+      const allCoordinates = advisories
+        .map(advisory => advisory.geometry.coordinates)
+        .flat(3);
+      fitMap(allCoordinates, mapView);
+    }
+  }, []);
 
   return (
     <div className="popup popup--advisories" tabIndex={0}>

--- a/src/frontend/src/Components/map/panels/index.js
+++ b/src/frontend/src/Components/map/panels/index.js
@@ -44,8 +44,9 @@ export const renderPanel = (clickedFeature, isCamDetail, routeDetails, smallScre
 export const maximizePanel = (panelRef) => {
   if (panelRef.current.classList.contains('open') &&
       !panelRef.current.classList.contains('maximized')) {
-    panelRef.current.classList.add('maximized');
-  }
+    // Prevent maximizing advisory panel on mobile view
+    // panelRef.current.classList.add('maximized');
+  } 
 }
 
 export const togglePanel = (panelRef, resetClickedStates, clickedFeatureRef, updateClickedFeature, pushMargins) => {

--- a/src/frontend/src/Components/map/panels/index.js
+++ b/src/frontend/src/Components/map/panels/index.js
@@ -44,8 +44,10 @@ export const renderPanel = (clickedFeature, isCamDetail, routeDetails, smallScre
 export const maximizePanel = (panelRef) => {
   if (panelRef.current.classList.contains('open') &&
       !panelRef.current.classList.contains('maximized')) {
-    // Prevent maximizing advisory panel on mobile view
-    // panelRef.current.classList.add('maximized');
+        // Prevent maximizing advisory panel on mobile view
+        if (!panelRef.current.innerText.includes("Advisories\n")){
+          panelRef.current.classList.add('maximized');
+        }
   } 
 }
 


### PR DESCRIPTION
DBC22-2905: centered the map only for the first loading when advisories are available

The fix moved the logic of the center map to an useEffect hook that only can be executed for the first loading, to avoid the behavior that center the map when the user panning or zooming in/out.

Jira: https://moti-imb.atlassian.net/browse/DBC22-2905