### PR TITLE
DBC22-2922: Add automated smoke testing to dev/test

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -162,3 +162,11 @@ jobs:
       run: |
         helm dependency update ./infrastructure/main
         helm upgrade dev-drivebc -f ./infrastructure/main/values-dev.yaml ./infrastructure/main --set django.image.tag="${{ github.sha }}" --set redis.image.tag="${{ github.sha }}" --set static.image.tag="${{ github.sha }}" --set tasks.image.tag="${{ github.sha }}" --set openshiftjobs.image.tag="${{ github.sha }}"
+
+
+  automatedTests:
+    needs: [versionUpdate]
+    name: Automated Smoke Test
+    uses: bcgov/DriveBC.ca-automated-tests/.github/workflows/playwright.yml@main
+    with:
+      environment: 'dev'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,3 +247,11 @@ jobs:
       run: |
         helm dependency update ./infrastructure/main
         helm upgrade test-drivebc -f ./infrastructure/main/values-test.yaml ./infrastructure/main --set django.image.tag="${{ needs.tag.outputs.tag }}" --set redis.image.tag="${{ needs.tag.outputs.tag }}" --set static.image.tag="${{ needs.tag.outputs.tag }}" --set tasks.image.tag="${{ needs.tag.outputs.tag }}" --set openshiftjobs.image.tag="${{ needs.tag.outputs.tag }}"
+
+
+  automatedTests:
+    needs: [versionUpdate]
+    name: Automated Smoke Test
+    uses: bcgov/DriveBC.ca-automated-tests/.github/workflows/playwright.yml@main
+    with:
+      environment: 'test'


### PR DESCRIPTION
https://moti-imb.atlassian.net/browse/DBC22-2922
This adds automated smoke testing to the dev & test github actions. 
Once any issues have been ironed out, we will look at adding it to UAT/Prod as well.