### PR TITLE
DBC22-2776 Event panel replaced by route panel

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -400,7 +400,7 @@ export default function DriveBCMap(props) {
 
     loadLayer(
       mapLayers, mapRef, mapContext,
-      'routeLayer', dl, dl, 3, null, updateReferenceFeature
+      'routeLayer', dl, dl, 3, referenceData, updateReferenceFeature
     );
 
     if (selectedRoute && selectedRoute.routeFound) {
@@ -589,7 +589,8 @@ export default function DriveBCMap(props) {
 
         <div className="panel-content">
           {openPanel && (
-            (selectedRoute && selectedRoute.routeFound) && renderPanel(clickedFeature, null, {...routeDetails, ferries: selectedFerries, distance: routeDistance, distanceUnit: routeDistanceUnit}, smallScreen, mapView)
+            (selectedRoute && selectedRoute.routeFound)
+            && renderPanel(clickedFeature, null, {...routeDetails, ferries: selectedFerries, distance: routeDistance, distanceUnit: routeDistanceUnit}, smallScreen, mapView)
           )}
 
           {openPanel && (

--- a/src/frontend/src/Components/map/layers/routeLayer.js
+++ b/src/frontend/src/Components/map/layers/routeLayer.js
@@ -35,7 +35,9 @@ export function getRouteLayer(routeData, projectionCode, mapContext, referenceDa
           projectionCode,
         );
 
-        updateReferenceFeature(olFeatureForMap);
+        if (!referenceData.type) { // if there's no feature specified in the URL
+          updateReferenceFeature(olFeatureForMap);
+        }
 
         const centroidGeometry = new Point(
           olFeature.getGeometry().getCoordinates()[


### PR DESCRIPTION
Fixes race condition where the route panel would be displayed, replacing the appropriate event panel when the URL references the event