### PR TITLE
DBC22-2929-2: Update NGINX conf for API

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -96,7 +96,7 @@ server {
         proxy_cache_lock_timeout 10s;
         proxy_cache_revalidate on;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-        proxy_cache_valid 200 1m;
+        proxy_cache_valid 200 30s;
         add_header X-Proxy-Cache $upstream_cache_status;
         proxy_cache_bypass $http_cachebypass;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
https://moti-imb.atlassian.net/browse/DBC22-2929
As per our discussion we are adjusting the caching of /api/ to ensure users get updates to things like events, webcams, weather, etc a bit quicker.
May result in a bit higher load on django, but it wasn't seeing much load as is.