### PR TITLE
DBC22-2831: fixed vh calculation in mobile Safari

### DIFF
--- a/src/frontend/src/Components/report/ReportMap.js
+++ b/src/frontend/src/Components/report/ReportMap.js
@@ -169,6 +169,21 @@ export function ReportMap(props) {
     isInitialMount.current = false;
   };
 
+  // DBC22-2831: mobile Safari vh too large
+  useEffect(() => {
+    const setVh = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    };
+
+    setVh();
+    window.addEventListener('resize', setVh);
+
+    return () => {
+      window.removeEventListener('resize', setVh);
+    };
+  }, []);
+
   useEffect(() => {
     loadMap();
   });

--- a/src/frontend/src/Components/report/ReportMap.scss
+++ b/src/frontend/src/Components/report/ReportMap.scss
@@ -6,7 +6,7 @@
   @media (max-width: 767px) {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 58px);
+    height: calc(var(--vh, 1vh) * 100 - 58px);
   }
 
   .page-header__content, .page-subtitle, .report-map-wrap {
@@ -36,7 +36,7 @@
       }
 
       .report-map-wrap {
-        height: calc(100vh - 58px);
+        height: calc(var(--vh, 1vh) * 100 - 58px);
       }
     }
 
@@ -47,7 +47,7 @@
         padding-bottom: 0;
         overflow: hidden;
         transition: all 0.20s ease-in-out;
-        
+
         .back-link-wrap {
           overflow: hidden;
         }
@@ -68,7 +68,7 @@
         text-decoration: none;
         cursor: pointer;
         margin-bottom: 10px;
-  
+
         svg {
           margin-right: 8px;
         }
@@ -88,7 +88,7 @@
   .page-subtitle {
     padding-top: 16px;
     padding-bottom: 16px;
-    
+
     p {
       margin-bottom: 0;
     }


### PR DESCRIPTION
[DBC22-2831](https://moti-imb.atlassian.net/browse/DBC22-2831)

"The issue with 100vh in mobile Safari being taller than in other browsers like Chrome is due to how mobile Safari handles the viewport height. Mobile Safari includes the height of the browser's UI elements (like the address bar) in the 100vh calculation, which can cause the content to be taller than expected.

To address this, you can use a workaround that calculates the viewport height dynamically using JavaScript and sets a CSS variable. This ensures that the height is consistent across different browsers."