### PR TITLE
DBC22-2926: added combine checks to ensure that mapLayers.current contains at least one property

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -442,7 +442,7 @@ export default function DriveBCMap(props) {
   // Events layer
   useEffect(() => {
     // Add layers if not loaded
-    if (!mapLayers.current['majorEvents']) {
+    if (mapLayers.current && Object.keys(mapLayers.current).length > 0 && !mapLayers.current['majorEvents']) {
       const eventFound = loadEventsLayers(events, mapContext, mapLayers, mapRef, referenceData, updateReferenceFeature, setLoadingLayers);
 
       if (referenceData?.type === 'event' && !eventFound) {


### PR DESCRIPTION
DBC22-2926: added combine checks to ensure that mapLayers.current contains at least one property