### PR TITLE
DBC22-2932, 2948, 2987, 3007, 3006, 3005: Updates to Env Canada Alerts

### DIFF
--- a/src/backend/apps/feed/client.py
+++ b/src/backend/apps/feed/client.py
@@ -431,8 +431,9 @@ class FeedClient:
                     if warnings.get("Events"):
                         # Filter out any events with Type "ended"
                         warnings["Events"] = [event for event in warnings["Events"] if event.get("Type") != "ended"]
-
-                    if not warnings["Events"]:
+                        if len(warnings["Events"]) == 0: 
+                            warnings = None
+                    else:
                         warnings = None
 
 

--- a/src/backend/apps/weather/admin.py
+++ b/src/backend/apps/weather/admin.py
@@ -1,4 +1,4 @@
-from apps.weather.models import CurrentWeather, RegionalWeather
+from apps.weather.models import CurrentWeather, RegionalWeather, HighElevationForecast
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 
@@ -6,6 +6,9 @@ from django.contrib.admin import ModelAdmin
 class WeatherAdmin(ModelAdmin):
     readonly_fields = ('id', )
 
+class HefAdmin(ModelAdmin):
+    readonly_fields = ('code', )
 
 admin.site.register(RegionalWeather, WeatherAdmin)
 admin.site.register(CurrentWeather, WeatherAdmin)
+admin.site.register(HighElevationForecast, HefAdmin)

--- a/src/backend/apps/weather/serializers.py
+++ b/src/backend/apps/weather/serializers.py
@@ -126,6 +126,8 @@ class HighElevationForecastSerializer(serializers.ModelSerializer):
 
     id = serializers.SerializerMethodField()
     location = GeometryField()
+    hwyName = serializers.SerializerMethodField()
+    hwyDescription = serializers.SerializerMethodField()
 
     class Meta:
         model = HighElevationForecast
@@ -137,3 +139,11 @@ class HighElevationForecastSerializer(serializers.ModelSerializer):
 
     def get_id(self, obj):
         return obj.code
+    
+    def get_hwyName(self, obj):
+        parts = obj.name.split('-')
+        return parts[0].strip() if parts else ""
+
+    def get_hwyDescription(self, obj):
+        parts = obj.name.split('-')
+        return parts[1].strip() if len(parts) > 1 else ""

--- a/src/frontend/src/Components/map/panels/weather/HefPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/HefPanel.js
@@ -6,7 +6,10 @@ import { useSearchParams } from 'react-router-dom';
 
 // External imports
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faMountain } from '@fortawesome/pro-solid-svg-icons';
+import {
+  faMountain,
+  faTriangleExclamation,
+} from '@fortawesome/pro-solid-svg-icons';
 
 // Internal imports
 import FriendlyTime from '../../../shared/FriendlyTime';
@@ -44,6 +47,28 @@ export default function HefPanel(props) {
         </div>
       </div>
 
+      { data.warnings && (
+        <div className="popup__advisory">
+          { data.warnings.Events.map(event => {
+            return <div key={ event.expirytime } className="event">
+              <FontAwesomeIcon icon={faTriangleExclamation} />
+              <p className="advisory-title">{ event.Description }</p>
+              {event.Url && (
+                <p className="label link">
+                <a
+                  alt="Environment Canada Details Link"
+                  target="_blank"
+                  rel="noreferrer"
+                  href={ event.Url }>
+                  Details
+                </a>
+              </p>
+              )}
+            </div>;
+          })}
+        </div>
+      )}
+
       <div className="popup__content">
         <div className="popup__content__title">
           <p className="name">{data.name}</p>
@@ -64,7 +89,18 @@ export default function HefPanel(props) {
             </div>
           ))}
         </div>
+        <div className="popup__content__additional">
+          <p className="label">
+            Courtesy of&nbsp;
 
+            <a alt="Environment Canada"
+              target="_blank"
+              rel="noreferrer"
+              href="https://weather.gc.ca/canada_e.html">
+              Environment Canada
+            </a>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/frontend/src/Components/map/panels/weather/HefPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/HefPanel.js
@@ -42,7 +42,7 @@ export default function HefPanel(props) {
         </div>
 
         <div className="popup__title__name">
-          <p className='name'>High Elevation Forecast</p>
+          <p className='name'>High Elevation Weather</p>
           <ShareURLButton />
         </div>
       </div>
@@ -71,7 +71,8 @@ export default function HefPanel(props) {
 
       <div className="popup__content">
         <div className="popup__content__title">
-          <p className="name">{data.name}</p>
+          <p className="highway">{data.hwyName}</p>
+          <p className="name">{data.hwyDescription}</p>
           { data.issued_utc && <FriendlyTime date={data.issued_utc} asDate={true} /> }
         </div>
 

--- a/src/frontend/src/Components/map/panels/weather/HefPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/HefPanel.scss
@@ -23,7 +23,87 @@
       }
     }
 
+    .popup__advisory, .popup__info {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      background-color: $Gold60;
+      color: $Gold110;
+      padding: 0.875rem;
+      font-size: 0.875rem;
+
+      .event {
+        display: flex;
+        width: 100%;
+        align-items: center;
+        justify-content: space-between;
+
+        &:not(:last-child) {
+          margin-bottom: 1rem; 
+        }
+
+        p {
+          line-height: 1.3;
+        }
+
+        svg {
+          margin-right: 0.5rem;
+        }
+      }
+
+      svg {
+        margin-right: 4px;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      .advisory-title {
+        font-size: 0.875rem;
+        font-weight: 700;
+        color: $Gold110;
+        margin-right: auto
+      }
+
+      .link {
+        min-width: max-content;
+        padding-left: 0.25rem;
+        margin-left: auto
+      }
+    }
+
+    .popup__info {
+      background-color: $Blue20;
+      flex-direction: column;
+      color: $Type-Link;
+
+      .event {
+        justify-content: space-between;
+
+        div {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+
+          svg, p {
+            color: $BC-Blue;
+          }
+        }
+
+        .expand-toggle {
+          cursor: pointer;
+          color: $Gold110;
+        }
+      }
+    }
+
+
     .popup__content {
+      display: flex;
+      flex-direction: column;
+      height: 100%; 
+      
       p {
         margin-bottom: 0;
       }
@@ -47,6 +127,7 @@
       &__forecasts {
         padding-top: 0;
         margin: 0 1rem;
+        flex-grow: 1;
 
         .forecast {
           margin-top: 1rem;
@@ -73,6 +154,23 @@
           .summary {
             font-size: 0.925rem;
           }
+        }
+      }
+      &__additional {
+        padding: 0.5rem 1rem;
+        margin-top: auto;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+
+        p {
+          text-align: center;
+          color: $Type-Secondary;
+          line-height: 1.5rem;
+        }
+
+        .label {
+          line-height: 2rem;
         }
       }
     }

--- a/src/frontend/src/Components/map/panels/weather/HefPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/HefPanel.scss
@@ -109,6 +109,12 @@
       }
 
       &__title {
+        .highway {
+          color: $Type-Primary;
+          font-size: 0.875rem;
+          margin-bottom: 0;
+        }
+        
         .name {
           color: $Type-Primary;
           font-size: 1.75rem;

--- a/src/frontend/src/Components/map/panels/weather/LocalWeatherPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/LocalWeatherPanel.js
@@ -186,7 +186,7 @@ export default function LocalWeatherPanel(props) {
           <p>Temperatures displayed in Celsius (&deg;C) <br /></p>
           <p>
             Local weather is provided by local Ministry of Transportation and Infrastructure weather stations. <br />
-            Forecasts courtesy of Weathernet.
+            {forecastData.length > 0 && <span>Forecasts courtesy of Weathernet.</span>}
           </p>
         </div>
       </div>

--- a/src/frontend/src/Components/map/panels/weather/LocalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/LocalWeatherPanel.scss
@@ -108,7 +108,7 @@
 
         .friendly-time-text {
           font-size: 0.875rem;
-          color: red;
+          color: $Grey80;
         }
 
         .temperature {

--- a/src/frontend/src/Components/map/panels/weather/LocalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/LocalWeatherPanel.scss
@@ -23,6 +23,10 @@
     }
 
     .popup__content {
+      display: flex;
+      flex-direction: column;
+      height: 100%; 
+
       p {
         margin-bottom: 0.4rem;
       }
@@ -50,6 +54,7 @@
       }
 
       &__description {
+        flex-grow: 1;
         & > div {
           padding-bottom: 1rem;
         }
@@ -73,6 +78,7 @@
       
       &__footer {
         padding: 1rem;
+        margin-top: auto;
   
         p {
           font-size: 0.875rem;

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
@@ -197,12 +197,14 @@ export default function RegionalWeatherPanel(props) {
             </div>
           </div>
         </div>
+        
+        <div className="popup__content__forecasts">
+          {weather.current_day_forecasts.length &&
+            <ForecastCarousel forecast_group={weather.current_day_forecasts} currentPane />
+          }
 
-        {weather.current_day_forecasts.length &&
-          <ForecastCarousel forecast_group={weather.current_day_forecasts} currentPane />
-        }
-
-        <ForecastTabs forecasts={weather.future_forecasts} sunset={weather.sunset} />
+          <ForecastTabs forecasts={weather.future_forecasts} sunset={weather.sunset} />
+        </div>
 
         <div className="popup__content__additional">
           { weather.station &&

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
@@ -79,27 +79,27 @@ export default function RegionalWeatherPanel(props) {
         </div>
       </div>
 
-      { weather.warnings &&
+      { weather.warnings && (
         <div className="popup__advisory">
           { weather.warnings.Events.map(event => {
             return <div key={ event.expirytime } className="event">
               <FontAwesomeIcon icon={faTriangleExclamation} />
               <p className="advisory-title">{ event.Description }</p>
+              {event.Url && (
+                <p className="label link">
+                <a
+                  alt="Environment Canada Details Link"
+                  target="_blank"
+                  rel="noreferrer"
+                  href={ event.Url }>
+                  Details
+                </a>
+              </p>
+              )}
             </div>;
           })}
-
-          <p className="label link">
-            <a
-              alt="Past 24 Hours"
-              target="_blank"
-              rel="noreferrer"
-              href={ weather.warnings.Url }>
-
-              Details
-            </a>
-          </p>
         </div>
-      }
+      )}
 
       {(!conditions.temperature_value || !weather.future_forecasts.length || !weather.current_day_forecasts.length) &&
         <div className="popup__info">

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
@@ -99,6 +99,10 @@
     }
 
     .popup__content {
+      display: flex;
+      flex-direction: column;
+      height: 100%; 
+
       p {
         margin-bottom: 0;
       }
@@ -148,12 +152,16 @@
         }
       }
 
+      &__forecasts {
+        flex-grow: 1;
+      }
+
       &__additional {
         padding: 0.5rem 1rem;
         display: flex;
         flex-direction: column;
-        flex-grow: 1;
         justify-content: space-between;
+        margin-top: auto;
 
         p {
           text-align: center;

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
@@ -25,8 +25,8 @@
 
     .popup__advisory, .popup__info {
       display: flex;
-      flex-direction: row;
-      align-items: center;
+      flex-direction: column;
+      align-items: stretch;
       background-color: $Gold60;
       color: $Gold110;
       padding: 0.875rem;
@@ -36,6 +36,11 @@
         display: flex;
         width: 100%;
         align-items: center;
+        justify-content: space-between;
+
+        &:not(:last-child) {
+          margin-bottom: 1rem;
+        }
 
         p {
           line-height: 1.3;
@@ -58,11 +63,13 @@
         font-size: 0.875rem;
         font-weight: 700;
         color: $Gold110;
+        margin-right: auto
       }
 
       .link {
         min-width: max-content;
         padding-left: 0.25rem;
+        margin-left: auto
       }
     }
 


### PR DESCRIPTION
DBC22-2932 - Fixed issue where Env Canada now only returns URL in each event which broke the displaying of events on the site (requires an API fix from the SAWSx team which is in their dev env right now. Expected to be in their prod in mid-Dec)
DBC22-2948 - Display multiple warnings on two rows instead of side by side, now each with their own details link.
DBC22-2987 - Updated styling show Highway Name/Number is on separate line of Highway Description. Also added "Courtesy of Environment Canada" text to the bottom.
DBC22-3007 - Footer not staying at bottom of the screen for MOTI weather. Also fixed for Regional Weather
DBC22-3006 - Forecasts mentioned when there are no forecasts
DBC22-3005 - Weathernet time in red

While doing this work I also ensured that weather alerts show on high elevation forecasts (filtering out ended alerts) (Same styling as used on regional weather)
I also added High Elevation Forecasts to the django-admin console so it's easier to see the data on the backend.