### PR TITLE
DBC22-2721 Filter user input through strip_tags

### DIFF
--- a/src/backend/apps/authentication/serializers.py
+++ b/src/backend/apps/authentication/serializers.py
@@ -1,5 +1,7 @@
-from apps.authentication.models import FavouritedCameras, SavedRoutes
 from rest_framework import serializers
+
+from apps.authentication.models import FavouritedCameras, SavedRoutes
+from apps.shared.serializers import SafeStringMixin
 
 
 class FavouritedCamerasSerializer(serializers.ModelSerializer):
@@ -9,7 +11,8 @@ class FavouritedCamerasSerializer(serializers.ModelSerializer):
         fields = ('webcam',)
 
 
-class SavedRoutesSerializer(serializers.ModelSerializer):
+class SavedRoutesSerializer(SafeStringMixin, serializers.ModelSerializer):
+
     class Meta:
         model = SavedRoutes
         fields = ('id', 'label', 'distance', 'distance_unit',

--- a/src/backend/apps/shared/fields.py
+++ b/src/backend/apps/shared/fields.py
@@ -1,0 +1,16 @@
+from django.utils.html import strip_tags
+from rest_framework import serializers
+
+
+class SafeStringField(serializers.CharField):
+    '''
+    A field that strips HTML from string content, incoming and outgoing
+
+    Currently only runs Django's strip_tags on input/output.
+    '''
+
+    def to_internal_value(self, data):
+        return strip_tags(data)
+
+    def to_representation(self, value):
+        return strip_tags(value)

--- a/src/backend/apps/shared/fields.py
+++ b/src/backend/apps/shared/fields.py
@@ -10,7 +10,9 @@ class SafeStringField(serializers.CharField):
     '''
 
     def to_internal_value(self, data):
+        data = super().to_internal_value(data)
         return strip_tags(data)
 
     def to_representation(self, value):
+        value = super().to_representation(value)
         return strip_tags(value)

--- a/src/backend/apps/shared/serializers.py
+++ b/src/backend/apps/shared/serializers.py
@@ -1,0 +1,23 @@
+from django.db.models import fields
+
+from .fields import SafeStringField
+
+
+class SafeStringMixin:
+    '''
+    Swaps SafeStringField in for char/text fields for ModelSerializers
+
+    This mixin alters the default model field -> DRF field mapping so that
+    model char and text fields become SafeStringFields instead of the DRF
+    CharField.
+
+    NOTE: applying this mixin will cause SafeStringField to be used for ALL
+    char/text fields, which may be broadly desireable for any serializer
+    handling user input.  This behaviour may be overridden on a field basis in
+    a serializer by declaring explicit fields.
+    '''
+
+    def build_standard_field(self, field_name, model_field):
+        self.serializer_field_mapping[fields.CharField] = SafeStringField
+        self.serializer_field_mapping[fields.TextField] = SafeStringField
+        return super().build_standard_field(field_name, model_field)


### PR DESCRIPTION
This PR implements a serializer mixin and custom field, for use with model serializers.  The mixin causes DRF to use the custom field instead of DRF's CharField for model char/text fields.  The custom field runs Django's strip_tags on input and output.