### PR TITLE
DBC22-3050

### DIFF
--- a/src/frontend/src/Components/events/EventCard.js
+++ b/src/frontend/src/Components/events/EventCard.js
@@ -23,11 +23,10 @@ export default function EventCard(props) {
   // Rendering
   return (
     <div
-      ref={childRef}
       className={'event-card ' + (event ? event.severity.toLowerCase() : '') + ((event && event.highlight) ? ' highlighted' : '')}
       data-key={event ? event.id : ''}
     >
-      <div className="event-card__title">
+      <div ref={childRef} className="event-card__title" data-key={event ? event.id : ''}>
         { showLoader ? <Skeleton width={75} /> : <div className="event-header"><div className="eventType"><EventTypeIcon event={event} state={event.display_category === 'majorEvents' ? 'static' : 'active'} />
             <span className="eventType__text">{getTypeDisplay(event)}
             </span>

--- a/src/frontend/src/Components/events/EventsTable.js
+++ b/src/frontend/src/Components/events/EventsTable.js
@@ -200,8 +200,6 @@ export default function EventsTable(props) {
         severity.toLowerCase() +
         " delay";
 
-    } else if (columnId === "map") {
-      return "View on map";
     }
 
     return "";
@@ -224,13 +222,6 @@ export default function EventsTable(props) {
           <td colSpan={2}>
             <p className={'roadName'}>{row.original.route_at}</p>
             <p className={'directionDisplay'}>{row.original.direction_display}</p>
-            <Button
-              className="viewOnMap-btn"
-              aria-label="View on map"
-              onClick={() => routeHandler(row.original)}>
-              <FontAwesomeIcon icon={faLocationDot} />
-              <span>View on map</span>
-            </Button>
           </td>
           <td colSpan={3}>
             <div className="space-between-row">
@@ -258,6 +249,20 @@ export default function EventsTable(props) {
               </td>
             );
           })}
+        </tr>
+      );
+
+      res.push(
+        <tr className={`${row.original.severity.toLowerCase()} mapLinkRow`} key={`${row.id}-map-link-row`}>
+          <td colSpan={5} className={'map'} title={'View on map'}>
+              <Button
+                className="viewOnMap-btn"
+                aria-label="View on map"
+                onClick={() => routeHandler(row.original)}>
+                <FontAwesomeIcon icon={faLocationDot} />
+                <span>View on map</span>
+              </Button>
+          </td>
         </tr>
       );
     }

--- a/src/frontend/src/Components/events/EventsTable.js
+++ b/src/frontend/src/Components/events/EventsTable.js
@@ -254,7 +254,7 @@ export default function EventsTable(props) {
 
       res.push(
         <tr className={`${row.original.severity.toLowerCase()} mapLinkRow`} key={`${row.id}-map-link-row`}>
-          <td colSpan={5} className={'map'} title={'View on map'}>
+          <td colSpan={5} className={'map'} title="">
               <Button
                 className="viewOnMap-btn"
                 aria-label="View on map"

--- a/src/frontend/src/Components/events/EventsTable.scss
+++ b/src/frontend/src/Components/events/EventsTable.scss
@@ -26,7 +26,7 @@ table {
     tr {
       &:focus {
         outline: 0;
-        box-shadow: none; 
+        box-shadow: none;
       }
       &.major, &.closure {
 
@@ -56,10 +56,6 @@ table {
       }
     }
 
-    tr:focus {
-      background-color: $BC-Blue-Light;
-    }
-
     .headerRow {
       &.highlighted {
         background-color: $Blue20;
@@ -70,7 +66,7 @@ table {
 
         &:hover {
           background-color: $Blue20;
-        }  
+        }
       }
 
       td {
@@ -97,7 +93,7 @@ table {
     }
 
     .dataRow {
-      border-bottom: 1px solid $Divider;
+      border-bottom: 1px solid $Table-row;
 
       td {
         padding-top: 0;

--- a/src/frontend/src/Components/events/EventsTable.scss
+++ b/src/frontend/src/Components/events/EventsTable.scss
@@ -110,7 +110,7 @@ table {
     }
 
     .mapLinkRow {
-      border-bottom: 1px solid $Table-row;
+      border-bottom: 1px solid $Divider;
 
       td {
         padding-top: 0;

--- a/src/frontend/src/Components/events/EventsTable.scss
+++ b/src/frontend/src/Components/events/EventsTable.scss
@@ -62,6 +62,10 @@ table {
 
         & + .dataRow, & + .dataRow:hover {
           background-color: $Blue20;
+
+          & + .mapLinkRow, & + .mapLinkRow:hover {
+            background-color: $Blue20;
+          }
         }
 
         &:hover {
@@ -93,24 +97,25 @@ table {
     }
 
     .dataRow {
+      td {
+        padding-top: 0;
+        padding-bottom: 0;
+        vertical-align: top;
+
+        &.location_description span {
+          display: inline-block;
+          padding-bottom: 16px;
+        }
+      }
+    }
+
+    .mapLinkRow {
       border-bottom: 1px solid $Table-row;
 
       td {
         padding-top: 0;
         padding-bottom: 16px;
         vertical-align: top;
-      }
-    }
-  }
-
-  td {
-    padding: 0 16px;
-  }
-  th {
-    padding: 1rem 0 1rem 1rem;
-    vertical-align: middle;
-  }
-}
 
 .viewOnMap-btn {
   font-weight: 700;
@@ -121,9 +126,17 @@ table {
   padding: 8px 16px;
   margin-top: 1rem;
   margin-bottom: 0;
-  font-size: 0.875rem;  
+  font-size: 0.875rem;
   svg {
     margin-right: 8px;
+  }
+
+  td {
+    padding: 0 16px;
+  }
+  th {
+    padding: 1rem 0 1rem 1rem;
+    vertical-align: middle;
   }
 }
 

--- a/src/frontend/src/pages/EventsListPage.js
+++ b/src/frontend/src/pages/EventsListPage.js
@@ -337,7 +337,10 @@ export default function EventsListPage() {
 
         setUpdateCounts(counts);
       },
-      { threshold: 0 }
+      {
+        rootMargin: "-58px 0px 0px 0px", // Factor in the height of the header
+        threshold: 1 // Trigger when the entire header element is in the viewport
+      }
     );
 
     Object.values(eventRefs.current).forEach((ref) => {

--- a/src/frontend/src/pages/EventsListPage.js
+++ b/src/frontend/src/pages/EventsListPage.js
@@ -395,6 +395,32 @@ export default function EventsListPage() {
     );
   };
 
+  const scrollToNextHighlightedEventHandler = (direction) => {
+    const offset = 58 + 48; // Offset Y position by 58px to account for the header + 48px of padding
+
+    // Get all highlighted events that are not in the viewport and sort them by their position
+    const sortedRefs = Object.entries(eventRefs.current)
+      .filter(([key, ref]) => ref.highlight && !eventBeenInViewPort.current[key])
+      .map(([key, ref]) => ({
+        key,
+        top: Math.floor(ref.element.getBoundingClientRect().top + window.scrollY - offset)
+      }))
+      .sort((a, b) => a.top - b.top);
+
+    const currentScrollPosition = Math.floor(window.scrollY);
+    let nextElementTopPosition;
+
+    if (direction === 'above') {
+      nextElementTopPosition = sortedRefs.reverse().find(ref => ref.top < currentScrollPosition)?.top;
+    } else if (direction === 'below') {
+      nextElementTopPosition = sortedRefs.find(ref => ref.top > currentScrollPosition)?.top;
+    }
+
+    if (nextElementTopPosition !== undefined) {
+      window.scrollTo({ top: nextElementTopPosition, behavior: 'smooth' });
+    }
+  };
+
   // Rendering - Sorting
   const getSortingDisplay = (key) => {
     const sortingDisplayMap = {
@@ -558,8 +584,8 @@ export default function EventsListPage() {
               }
             </div>
 
-          {updateCounts.above > 0 && <div className="update-count-pill top"><FontAwesomeIcon icon={faArrowUp} /> {updateCounts.above} update{updateCounts.above !== 1 ? 's' : ''} available</div>}
-          {updateCounts.below > 0 && <div className="update-count-pill bottom"><FontAwesomeIcon icon={faArrowDown} /> {updateCounts.below} update{updateCounts.below !== 1 ? 's' : ''} available</div>}
+          {updateCounts.above > 0 && <button className="update-count-pill top" onClick={() => scrollToNextHighlightedEventHandler('above')}><FontAwesomeIcon icon={faArrowUp} /> {updateCounts.above} update{updateCounts.above !== 1 ? 's' : ''} available</button>}
+          {updateCounts.below > 0 && <button className="update-count-pill bottom" onClick={() => scrollToNextHighlightedEventHandler('below')}><FontAwesomeIcon icon={faArrowDown} /> {updateCounts.below} update{updateCounts.below !== 1 ? 's' : ''} available</button>}
 
           </div>
         </Container>

--- a/src/frontend/src/pages/EventsListPage.scss
+++ b/src/frontend/src/pages/EventsListPage.scss
@@ -180,10 +180,15 @@
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
+  border: none;
   border-radius: 24px;
   padding: 4px 12px;
   z-index: 1000;
   white-space: nowrap;
+
+  &:hover {
+    background-color: $Blue70;
+  }
 
   &.top {
     top: calc(58px + 9px);

--- a/src/frontend/src/styles/variables.scss
+++ b/src/frontend/src/styles/variables.scss
@@ -43,6 +43,7 @@ $Black: #000000;
 $Blue10: #F1F8FE;
 $Blue20: #D8EAFD;
 $Blue30: #C1DDFC;
+$Blue70: #5595D9;
 $Blue80: #3470B1;
 $Blue90: #1E5189;
 

--- a/src/frontend/src/styles/variables.scss
+++ b/src/frontend/src/styles/variables.scss
@@ -7,6 +7,7 @@ $Type-Link: #255A90;
 //Dividers & Border
 $Divider: #FAF9F8;
 $Input-border: #8A8886;
+$Table-row: #d9d9d9;
 
 //BC Theme
 $BC-Blue: #013366;

--- a/src/frontend/src/styles/variables.scss
+++ b/src/frontend/src/styles/variables.scss
@@ -5,9 +5,8 @@ $Type-Disabled: #9F9D9C;
 $Type-Link: #255A90;
 
 //Dividers & Border
-$Divider: #FAF9F8;
+$Divider: #D8D8D8;
 $Input-border: #8A8886;
-$Table-row: #d9d9d9;
 
 //BC Theme
 $BC-Blue: #013366;


### PR DESCRIPTION
Bugfixes for the following items:

1. Fix incorrect event table divider colour (James indicated `$Divider` could be changed, rather than just applying a specific colour for the event table
2. Remove the over colour for events when the header is clicked
3. Use the card header for the IntersectionObserver rather than the entire card, which is consistent with the table
4. Move the `View on Map` to a third row for the event table
5. Make the `X updates available` pills clickable
6. Adjust the IntersectionObserver `rootMargin` and `threshold`