### PR TITLE
Bugfix/dbc22-3062

### DIFF
--- a/src/frontend/src/Components/events/EventCard.scss
+++ b/src/frontend/src/Components/events/EventCard.scss
@@ -11,6 +11,8 @@
 
     .event-header {
       padding: 8px 12px;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
 
       .eventType {
         padding: 0;
@@ -30,23 +32,26 @@
       .header {
         color: $BC-Blue;
         width: fit-content;
+        font-size: 0.875rem;
         flex: 0 0 116px;
         display: flex;
         padding: 8px 8px 8px 12px;
       }
 
       .content {
-        color: $BC-Blue;
-        padding: 12px;
+        color: $Type-Primary;
+        font-size: 0.875rem;
+        padding: 8px;
         flex-grow: 1;
         display: flex;
-        align-items: center;
+        align-items: baseline;
       }
     }
 
     .name {
       .content {
         display: block;
+        padding: 8px 12px;
         
         .route {
           font-size: 1.25rem;
@@ -76,6 +81,9 @@
     .viewOnMap-btn {
       width: 100%;
       padding: 12px;
+    }
+    .friendly-time-text {
+      font-size: 0.875rem;
     }
   }
 

--- a/src/frontend/src/Components/events/EventsTable.scss
+++ b/src/frontend/src/Components/events/EventsTable.scss
@@ -117,15 +117,15 @@ table {
 }
 
 .viewOnMap-btn {
-  font-size: 0.875rem;
   font-weight: 700;
   color: $Type-Link;
   border: none;
-  border-radius: 8px;
+  border-radius: 4px;
   background: $Grey10;
   padding: 8px 16px;
   margin-top: 1rem;
-
+  margin-bottom: 0;
+  font-size: 0.875rem;  
   svg {
     margin-right: 8px;
   }

--- a/src/frontend/src/Components/map/panels/weather/ForecastCarousel.js
+++ b/src/frontend/src/Components/map/panels/weather/ForecastCarousel.js
@@ -84,7 +84,7 @@ export default function ForecastCarousel(props) {
         currentPane={currentPane}
         itemsPerPane={1}
         gap={16}
-        itemPeek={32}
+        itemPeek={12}
         animationDuration={0.4}>
 
         {carouselList}

--- a/src/frontend/src/Components/map/panels/weather/ForecastCarousel.scss
+++ b/src/frontend/src/Components/map/panels/weather/ForecastCarousel.scss
@@ -5,7 +5,7 @@
 }
 
 .carousel-container {
-  padding: 1rem;
+  padding: 1rem 0;
   position: relative;
 
   .GoodCarousel {
@@ -96,16 +96,27 @@
     box-shadow: 0px 3.2px 7.2px 0px #00000021, 0px 0.6px 1.8px 0px #0000001A;
 
     &:focus, &:active, &:hover {
-      background-color: $Grey10;
+      background-color: $Grey40;
+      color: $Type-Primary;
       border: 1px solid $Input-border;
     }
 
     &.next {
-      right: 1rem;
+      right: 0;
+      animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
     }
 
     &.prev {
-      left: 1rem;
+      left: 0;
+      animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;      
     }
   }
 }
+
+@keyframes show {
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+

--- a/src/frontend/src/Components/map/panels/weather/ForecastTabs.scss
+++ b/src/frontend/src/Components/map/panels/weather/ForecastTabs.scss
@@ -1,7 +1,7 @@
 @import "../../../../styles/variables";
 
 .forecast-container {
-  padding: 1rem 1rem 0 1rem;
+  padding: 1rem 0 0;
 }
 
 .forecast-tab-list {
@@ -11,7 +11,7 @@
     border-bottom: 1px solid #D9D9D9;
     margin-top: 1rem;
     margin-bottom: 0.5rem;
-    padding: 0 0.5rem;
+    padding: 0;
 
     li, button, div {
       display: flex;
@@ -20,6 +20,9 @@
 
     .nav-item {
       padding: 0 0.5rem;
+      &:first-child, &:last-child {
+        padding: 0;
+      }
 
       button {
         padding: 0;

--- a/src/frontend/src/Components/map/panels/weather/ForecastTabs.scss
+++ b/src/frontend/src/Components/map/panels/weather/ForecastTabs.scss
@@ -17,10 +17,13 @@
       display: flex;
       flex: 1;
     }
+    li {
+      flex: 0 auto;
+    }
 
     .nav-item {
-      padding: 0 0.5rem;
-      &:first-child, &:last-child {
+      padding-right: 1rem;
+      &:last-child {
         padding: 0;
       }
 

--- a/src/frontend/src/Components/map/panels/weather/HefPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/HefPanel.scss
@@ -132,7 +132,7 @@
 
       &__forecasts {
         padding-top: 0;
-        margin: 0 1rem;
+        margin: 0;
         flex-grow: 1;
 
         .forecast {

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
@@ -200,7 +200,7 @@ export default function RegionalWeatherPanel(props) {
         
         <div className="popup__content__forecasts">
           {weather.current_day_forecasts.length &&
-            <ForecastCarousel forecast_group={weather.current_day_forecasts} currentPane />
+            <ForecastCarousel forecast_group={weather.current_day_forecasts} className={'test'} currentPane />
           }
 
           <ForecastTabs forecasts={weather.future_forecasts} sunset={weather.sunset} />

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.js
@@ -125,7 +125,7 @@ export default function RegionalWeatherPanel(props) {
 
           <Collapse in={expanded}>
             <div id="collapse-text">
-              <br/>We haven’t received complete data from Environment Canada. It could be because it hasn’t been observed or wasn’t transmitted.<br/><br/>
+              We haven’t received complete data from Environment Canada. It could be because it hasn’t been observed or wasn’t transmitted.<br/><br/>
               For more information on why this might happen, read more on <a href="https://climate.weather.gc.ca/FAQ_e.html#Q4" target="_blank" rel="noreferrer">Environment Canada’s help page</a>
             </div>
           </Collapse>
@@ -200,7 +200,7 @@ export default function RegionalWeatherPanel(props) {
         
         <div className="popup__content__forecasts">
           {weather.current_day_forecasts.length &&
-            <ForecastCarousel forecast_group={weather.current_day_forecasts} className={'test'} currentPane />
+            <ForecastCarousel forecast_group={weather.current_day_forecasts} currentPane />
           }
 
           <ForecastTabs forecasts={weather.future_forecasts} sunset={weather.sunset} />

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
@@ -38,10 +38,6 @@
         align-items: center;
         justify-content: space-between;
 
-        &:not(:last-child) {
-          margin-bottom: 1rem;
-        }
-
         p {
           line-height: 1.3;
         }
@@ -93,7 +89,7 @@
 
         .expand-toggle {
           cursor: pointer;
-          color: $Gold110;
+          color: $Type-Link;
         }
       }
     }
@@ -102,6 +98,7 @@
       display: flex;
       flex-direction: column;
       height: 100%; 
+      overflow-x: hidden;
 
       p {
         margin-bottom: 0;
@@ -140,7 +137,9 @@
         }
 
         .weather-icon {
-          font-size: 4rem;
+          font-size: 7.375rem;
+          color: lighten(saturate($Type-Primary, 0.47), 40.59)
+
         }
 
         .weather {
@@ -148,7 +147,7 @@
         }
 
         .temperature {
-          font-size: 4rem;
+          font-size: 5.5rem;
         }
       }
 

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
@@ -29,7 +29,7 @@
       align-items: stretch;
       background-color: $Gold60;
       color: $Gold110;
-      padding: 0.875rem;
+      padding: 0.5rem 0.875rem;
       font-size: 0.875rem;
 
       .event {
@@ -37,6 +37,11 @@
         width: 100%;
         align-items: center;
         justify-content: space-between;
+        padding: 8px 0;
+        
+        &:only-child {
+          padding: 0.5rem 0;
+        }
 
         p {
           line-height: 1.3;
@@ -76,6 +81,15 @@
 
       .event {
         justify-content: space-between;
+
+        &:only-child {
+          padding: 0;
+          border: 1px solid red;
+        }
+
+        + div {
+          padding-bottom: 0.5rem;
+        }
 
         div {
           display: flex;

--- a/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
+++ b/src/frontend/src/Components/map/panels/weather/RegionalWeatherPanel.scss
@@ -129,7 +129,7 @@
           flex-direction: row;
           align-items: center;
           justify-content: space-between;
-          margin-bottom: 1rem;
+          margin-bottom: 1.5rem;
 
           p, .weather-icon {
             flex: 1;

--- a/src/frontend/src/Components/shared/FriendlyTime.scss
+++ b/src/frontend/src/Components/shared/FriendlyTime.scss
@@ -9,7 +9,7 @@
     cursor: pointer;
 
     time:hover {
-      color: $White;
+      color: $Grey70;
       text-decoration: underline;
     }
   }

--- a/src/frontend/src/Components/shared/header/Header.scss
+++ b/src/frontend/src/Components/shared/header/Header.scss
@@ -96,7 +96,7 @@
 	}
 
 	.nav-divider {
-		border: 1px solid $Divider;
+		border-right: 1px solid $Divider;
 		margin: 0 12px;
 		height: 38px;
 		display: none;

--- a/src/frontend/src/Components/shared/header/Header.scss
+++ b/src/frontend/src/Components/shared/header/Header.scss
@@ -47,13 +47,14 @@
 		padding: 0.5rem;
 		display: flex;
 		flex-direction: column;
-		justify-content: space-around;
+		justify-content: space-evenly;
+		align-items: center;
 		border: none;
 
 		.line {
 			background-color: $Type-Primary;
-			width: 2rem;
-			height: 0.25rem;
+			width: 1.6rem;
+			height: 0.125em;
 		}
 
 		.line1 {
@@ -68,7 +69,7 @@
 
 		&:not(.collapsed) {
 			.line {
-				margin-left: 6px;
+				margin-left: 8px;
 			}
 
 			.line1 {
@@ -136,7 +137,7 @@
 		.navbar-nav {
 			.nav-link {
 				color: $Type-Primary;
-				padding: 16px 0;
+				padding: 16px;
 				border-bottom: 1px solid $Nav-link-border;
 				cursor: pointer;
 				display: flex;
@@ -151,15 +152,26 @@
 				&:hover {
 					text-decoration: none;
 					background-color: hsla(0,0%,7%,.15);
+					svg {
+						transition: 0.2s ease-in-out all;
+						left: 0;
+						position: relative;
+					}
 				}
 
 				&:focus {
 					border: rgb(46, 93, 215) solid 2px;
-					background-color: hsla(0,0%,60%,.15);
+					background-color: hsla(0, 32%, 83%, 0.15);
 				}
 
 				&:active, &.active {
-					border-bottom: rgb(46, 93, 215) solid 2px;
+					font-weight: bold;
+					color: rgb(46, 93, 215);
+					@media (min-width: 992px) {
+						color: $Type-Primary;
+						font-weight: normal;
+						border-bottom: rgb(46, 93, 215) solid 2px;
+					}
 				}
 
 				.title {
@@ -182,13 +194,23 @@
 
 				svg {
 					font-size: 1.25rem;
+					position: relative;
+					left: -4px;
+					transition: 0.2s ease-in-out left;
 				}
 			}
 
 			.footer-nav-link {
 				font-size: 0.875rem;
 				border: none;
+				display: inline-block;
 				padding: 12px 0;
+				margin: 0 16px;
+				width: max-content;
+				&:hover {
+					background: transparent;
+					text-decoration: underline;
+				}
 
 				&:active, &.active {
 					border-bottom: none;
@@ -197,9 +219,8 @@
 				&:after {
 					content: none;
 				}
-
 				&.first-link {
-					margin-top: 12px;
+					margin-top: 8px;
 				}
 			}
 


### PR DESCRIPTION
regional weather sidepanel  
- fix some alignment/padding issues 
- removed extra bottom margin on blue "weather incomplete" banner 
- fixed horizontal scroll bug in regional weather panels
- updated spacing between current weather hero and current conditions heading
- updated 5 day forecast tab spacing behaviour on wider mobile screens

header nav
- border thickness for divider lines
- hamburger menu icon thickness
- interactive styles for mobile menu

friendly time
- fixed hover bug where text goes to white

delays list design qa for mobile cards
- corner radii on card and view on map button
- adjusted text baseline alignment
