### PR TITLE
DBC22-3047: show single route if the fastest route is the same as the shortest route

### DIFF
--- a/src/frontend/src/Components/map/helpers/index.js
+++ b/src/frontend/src/Components/map/helpers/index.js
@@ -3,7 +3,7 @@ import { onMoveEnd } from './advisories';
 import { setEventStyle } from './events';
 import { blueLocationMarkup, redLocationMarkup, redLocationToMarkup, setLocationPin } from './location';
 import { calculateCenter, fitMap, removeOverlays, setZoomPan, toggleMyLocation, transformFeature, zoomIn, zoomOut } from './map';
-import { compareRoutePoints, filterByRoute, filterAdvisoryByRoute, getMidPoint, populateRouteProjection } from './spatial';
+import { compareRoutePoints, compareRouteDistance, filterByRoute, filterAdvisoryByRoute, getMidPoint, populateRouteProjection } from './spatial';
 
 export {
   // advisories,
@@ -15,5 +15,5 @@ export {
   // map
   calculateCenter, fitMap, setZoomPan, toggleMyLocation, transformFeature, zoomIn, zoomOut, removeOverlays,
   // spatial
-  compareRoutePoints, filterByRoute, filterAdvisoryByRoute, getMidPoint, populateRouteProjection
+  compareRoutePoints, compareRouteDistance, filterByRoute, filterAdvisoryByRoute, getMidPoint, populateRouteProjection
 };

--- a/src/frontend/src/Components/map/helpers/spatial.js
+++ b/src/frontend/src/Components/map/helpers/spatial.js
@@ -140,6 +140,13 @@ export const compareRoutePoints = (routePoints, savedPoints) => {
   return routePoints == savedPoints;
 }
 
+export const compareRouteDistance = (route1, route2) => {
+  if (!!route1 && !!route2) {
+    return Math.abs(route1.distance - route2.distance) < 1;
+  }
+  return true;
+}
+
 export const getMidPoint = (location) => {
   // Return point coords if location is a point
   if (location.type === "Point") {

--- a/src/frontend/src/Components/routing/RouteDetails.js
+++ b/src/frontend/src/Components/routing/RouteDetails.js
@@ -33,7 +33,7 @@ import {getRoute, removeRoute, saveRoute} from "../data/routes";
 import { addCameraGroups } from "../data/webcams";
 import { getEventCounts } from "../data/events";
 import { getAdvisoryCounts } from "../data/advisories";
-import { filterAdvisoryByRoute } from '../map/helpers';
+import { compareRouteDistance, filterAdvisoryByRoute } from '../map/helpers';
 import * as dataLoaders from '../map/dataLoaders'
 import * as slices from '../../slices';
 import RouteMap from './RouteMap';
@@ -265,8 +265,15 @@ export default function RouteDetails(props) {
       [route.start_point.coordinates, route.end_point.coordinates],
       route.criteria === 'fastest'
     );
-    const searchedRoutesPayload = route.criteria === 'fastest' ? // Fastest before shortest
+    let searchedRoutesPayload = route.criteria === 'fastest' ? // Fastest before shortest
       [routePayload, alternateRoute] : [alternateRoute, routePayload];
+
+    const isSameRoute = compareRouteDistance(routePayload, alternateRoute);
+    if(isSameRoute){
+      searchedRoutesPayload = searchedRoutesPayload?.filter(route =>
+        Object.prototype.hasOwnProperty.call(route, 'id')
+      );
+    }
     dispatch(updateSearchedRoutes(searchedRoutesPayload));
 
     const startPayload = [{

--- a/src/frontend/src/Components/routing/RouteSearch.js
+++ b/src/frontend/src/Components/routing/RouteSearch.js
@@ -86,7 +86,7 @@ const RouteSearch = forwardRef((props, ref) => {
     const shortestRoute = await getRoute(points, true);
     if (shortestRoute && shortestRoute.routeFound) {
       const hasEqualDistance = compareRouteDistance(fastestRoute, shortestRoute);
-      if(! hasEqualDistance){
+      if(!hasEqualDistance){
         routes.push(shortestRoute);
       }
     }

--- a/src/frontend/src/Components/routing/RouteSearch.js
+++ b/src/frontend/src/Components/routing/RouteSearch.js
@@ -85,8 +85,8 @@ const RouteSearch = forwardRef((props, ref) => {
 
     const shortestRoute = await getRoute(points, true);
     if (shortestRoute && shortestRoute.routeFound) {
-      const isFastestIsShortest = compareRouteDistance(fastestRoute, shortestRoute);
-      if(! isFastestIsShortest){
+      const hasEqualDistance = compareRouteDistance(fastestRoute, shortestRoute);
+      if(! hasEqualDistance){
         routes.push(shortestRoute);
       }
     }

--- a/src/frontend/src/Components/routing/RouteSearch.js
+++ b/src/frontend/src/Components/routing/RouteSearch.js
@@ -8,6 +8,7 @@ import { useSearchParams } from "react-router-dom";
 
 // Internal imports
 import { getRoute } from '../data/routes.js';
+import { compareRouteDistance } from '../map/helpers';
 import {
   clearSearchedRoutes,
   clearSelectedRoute,
@@ -84,7 +85,10 @@ const RouteSearch = forwardRef((props, ref) => {
 
     const shortestRoute = await getRoute(points, true);
     if (shortestRoute && shortestRoute.routeFound) {
-      routes.push(shortestRoute);
+      const isFastestIsShortest = compareRouteDistance(fastestRoute, shortestRoute);
+      if(! isFastestIsShortest){
+        routes.push(shortestRoute);
+      }
     }
 
     return routes;


### PR DESCRIPTION
DBC22-3047: show single route if the fastest route is the same as the shortest route

The fix calculates route distance between the fastest and the shortest, to determine if the shortest route should be pushed to the routes list when searching route. When the user clicks "View on map", the searched routes will be filtered depending on if the fastest and shortest are the same or not. 