### PR TITLE
DBC22-2925: made sure the latest camera direction saved got the focus when saving camera

### DIFF
--- a/src/frontend/src/Components/cameras/CameraCard.js
+++ b/src/frontend/src/Components/cameras/CameraCard.js
@@ -37,7 +37,7 @@ import 'react-loading-skeleton/dist/skeleton.css'
 export default function CameraCard(props) {
   /* Setup */
   // Props
-  const { cameraData, showLoader } = props;
+  const { cameraData, showLoader, setFocusedButtonRef } = props;
 
   // Contexts
   const { authContext, setAuthContext } = useContext(AuthContext);
@@ -318,6 +318,7 @@ export default function CameraCard(props) {
 
         {authContext.loginStateKnown &&
           <button
+            ref={setFocusedButtonRef}
             className={`favourite-btn ${(favCams && favCams.includes(camera.id)) ? 'favourited' : ''}`}
             aria-label={`${(favCams && favCams.includes(camera.id)) ? 'Remove favourite' : 'Add favourite'}`}
             onClick={favoriteHandler}>

--- a/src/frontend/src/Components/cameras/HighwayGroup.js
+++ b/src/frontend/src/Components/cameras/HighwayGroup.js
@@ -1,5 +1,6 @@
 // React
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 // Components and functions
 import CameraCard from './CameraCard.js';
@@ -8,6 +9,13 @@ import highwayShield from './highwayShield';
 export default function HighwayGroup(props) {
   // Props
   const { highway, cams, showLoader} = props;
+  const focusedButtonRef = useRef(null);
+  const location = useLocation();
+  useEffect(() => {
+    if (location.pathname.includes("my-camera") && focusedButtonRef.current) {
+      focusedButtonRef.current.focus();
+    }
+  }, [cams, location.pathname]);
 
   return (
     <div className="highway-group">
@@ -31,7 +39,13 @@ export default function HighwayGroup(props) {
 
       <div className="webcam-group">
         {cams.map((cam, id) => (
-          <CameraCard cameraData={cam} className="webcam" key={id} showLoader={showLoader}/>
+          <CameraCard cameraData={cam} className="webcam" key={id} showLoader={showLoader} 
+            setFocusedButtonRef={(el) => {
+              if (id === cams.length - 1) {
+                focusedButtonRef.current = el;
+              }
+            }}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
DBC22-2925: made sure the latest camera direction saved got the focus when saving camera

The fix used function setFocusedButtonRef  that passed from HighwayGroup down to CameraCard to set the reference for the focused button dynamically when saving a new camera to make sure the latest saved camera has the focus on my camera view.