### PR TITLE
DBC22-3135 Save button for routes doesn't work

### DIFF
--- a/src/frontend/src/Components/routing/RouteDetails.scss
+++ b/src/frontend/src/Components/routing/RouteDetails.scss
@@ -11,7 +11,8 @@
         margin: 0;
         padding: 0;
         background: none;
-        
+        z-index: 10;
+
         svg {
           font-size: 16px;
         }
@@ -189,7 +190,7 @@
         border-left: 2px solid $Warning;
       }
 
-      &--chainUps { 
+      &--chainUps {
         border-left: 2px solid $Chainups;
       }
 


### PR DESCRIPTION
The save button's z-index was below the containing div's, which caught the click event.  Increasing the z-index resolves the issue.