### PR TITLE
DBC22-3158: set time format based on time zone of event location

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -56,6 +56,7 @@
         "react-scripts": "5.0.1",
         "react-time-ago": "^7.2.1",
         "redux-persist": "^6.0.0",
+        "tz-lookup": "^6.1.25",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -20646,6 +20647,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
+      "license": "CC0-1.0"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -51,6 +51,7 @@
     "react-scripts": "5.0.1",
     "react-time-ago": "^7.2.1",
     "redux-persist": "^6.0.0",
+    "tz-lookup": "^6.1.25",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/frontend/src/Components/map/panels/EventPanel.js
+++ b/src/frontend/src/Components/map/panels/EventPanel.js
@@ -67,13 +67,21 @@ export default function EventPanel(props) {
         <div className="popup__content__block">
           <div className="popup__content__description last-update">
             <p>Last update</p>
-            <FriendlyTime date={eventData.last_updated} />
+            <FriendlyTime date={eventData.last_updated} 
+              coordinates={
+                eventData.location.type === "LineString" ?
+                eventData.location.coordinates[0]: eventData.location.coordinates
+                }/>
           </div>
 
           {eventData.next_update &&
             <div className="popup__content__description next-update">
               <p>Next update</p>
-              <FriendlyTime date={eventData.next_update} isNextUpdate={true} />
+              <FriendlyTime date={eventData.next_update} isNextUpdate={true} 
+                coordinates={
+                  eventData.location.type === "LineString" ?
+                eventData.location.coordinates[0]: eventData.location.coordinates
+                }/>
             </div>
           }
         </div>

--- a/src/frontend/src/Components/shared/FriendlyTime.js
+++ b/src/frontend/src/Components/shared/FriendlyTime.js
@@ -5,34 +5,43 @@ import  {useState} from 'react';
 // Third Party packages
 import ReactTimeAgo from 'react-time-ago';
 import OutsideClickHandler from 'react-outside-click-handler';
+import tzLookup from 'tz-lookup';
 
 // Styling
 import './FriendlyTime.scss';
 
-const datetimeFormat = {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-  hour: 'numeric',
-  minute: 'numeric',
-  year: 'numeric',
-  timeZoneName: 'short',
-};
-const formatter = new Intl.DateTimeFormat('en-US', datetimeFormat);
 const ONE_DAY = 1000 * 60 * 60 * 24; // 24 hours in milliseconds
 
-export const formatDate = (date, isNextUpdate=false) => {
+export const formatDate = (date, isNextUpdate=false, coordinates) => {
+
+  let tz = undefined;
+  if(coordinates){
+    tz = tzLookup(coordinates[1], coordinates[0]);
+  }
+  
+  const datetimeFormat = {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      year: 'numeric',
+      timeZoneName: 'short',
+      timeZone: tz,
+    };
+
+  const formatter = new Intl.DateTimeFormat('en-US', datetimeFormat);
   // get time difference in milliseconds
   const timeDiff = (new Date() - new Date(date));
   return (isNextUpdate && timeDiff > 0) ? "Update expected as soon as possible, please continue to check back." : formatter.format(new Date(date));
 }
 
-export default function FriendlyTime({ date, asDate=false, includeFullIfHumanized=false, timeOnly=false, isNextUpdate=false }) {
+export default function FriendlyTime({ date, asDate=false, includeFullIfHumanized=false, timeOnly=false, isNextUpdate=false, coordinates }) {
   const [showTooltip, setShowTooltip] = useState(false);
 
   // get time difference in milliseconds
   const timeDiff = (new Date() - new Date(date));
-  const dateFormatted = formatDate(date, isNextUpdate);
+  const dateFormatted = formatDate(date, isNextUpdate, coordinates);
 
   // if difference is less than 24hrs
   const humanize = timeDiff < ONE_DAY;
@@ -80,7 +89,7 @@ export default function FriendlyTime({ date, asDate=false, includeFullIfHumanize
           >
             <div className="friendly-time-text">
               {(isNextUpdate && timeDiff > 0) ? "Update expected as soon as possible, please continue to check back." :
-                <ReactTimeAgo date={dt} locale="en-US"/>
+                <ReactTimeAgo date={dt} verboseDate={dateFormatted} locale="en-US"/>
               }
             </div>
             { !(isNextUpdate && timeDiff > 0) &&


### PR DESCRIPTION
DBC22-3158: set time format based on time zone of event location

This fix passes the location coordinates to the 'friendly time' component to determine the event's time zone, updating the tooltip and message with the corrected time format.