### PR TITLE
DBC-3196: Add oc installer in github actions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -149,6 +149,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4"
      
     - name: Authenticate and set context
       uses: redhat-actions/oc-login@v1

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -79,6 +79,11 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
 
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4"
+
     - name: Authenticate and set context
       uses: redhat-actions/oc-login@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,6 +235,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4"
+
     - name: Authenticate and set context
       uses: redhat-actions/oc-login@v1
       with:

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -238,6 +238,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4"
+
     - name: Authenticate and set context
       uses: redhat-actions/oc-login@v1
       with:


### PR DESCRIPTION
Ubuntu-latest image removed the Github action for oc (https://github.com/actions/runner-images/issues/10636)
I added a new step to install the latest version of oc tool so that it would run again.
This commit will need to be cherry-picked into the release branches as UAT and PROD releases will fail without this fix.