### PR TITLE
DBC22-3187: Add FuzzyMatch Parameter for geocoder

### DIFF
--- a/src/frontend/src/Components/data/locations.js
+++ b/src/frontend/src/Components/data/locations.js
@@ -8,8 +8,9 @@ export function getLocations(addressInput) {
       brief: true,
       autoComplete: true,
       addressString: addressInput,
-      exactSpelling: true,
+      exactSpelling: false,
       locationDescriptor: 'routingPoint',
+      fuzzyMatch: true,
     }, {
       'apiKey': `${window.GEOCODER_API_CLIENT_ID}`,
     }


### PR DESCRIPTION
https://moti-imb.atlassian.net/browse/DBC22-3187

This changes the parameters that get sent to the geocoder to use the new fuzzyMatch parameter (which looks to give better results). It also sets exactSpelling to false since that flag looks like it will provide much worse results than what we are currently getting.
This change will be required before the Geocoder 4.5 prod release on Jan 20th.
If this fix is not in prod on the 20th, the results will become almost unusable since it will return things like schools instead of cities