### PR TITLE
DBC22-3302: fixed the issue that camera does not show up when it's not a default camera

### DIFF
--- a/src/frontend/src/Components/cameras/CameraCard.js
+++ b/src/frontend/src/Components/cameras/CameraCard.js
@@ -98,6 +98,10 @@ export default function CameraCard(props) {
 
   }, [cameraData]);
 
+  useEffect(() => { 
+    setCamera(cameraData);
+  }, [cameraData]);
+
   // Misc
   const navigate = useNavigate();
 


### PR DESCRIPTION
DBC22-3302: fixed the issue that camera does not show up when it's not a default camera

When searching for a camera that is not the default camera in the processed camera list, the search result previously showed the default camera instead. This fix addresses the issue by updating the processed camera list for the search. It adds any potentially matching cameras to the list before performing the search. The fix also updated the search function to improve its logic, making it more accurate and easier to understand.