### PR TITLE
DBC22-3320: removed sub type from EVENT_UPDATE_FIELDS

### DIFF
--- a/src/backend/apps/event/enums.py
+++ b/src/backend/apps/event/enums.py
@@ -111,7 +111,6 @@ EVENT_UPDATE_FIELDS = [
     'start_point_linear_reference',
     'description',
     'event_type',
-    'event_sub_type',
     'status',
     'severity',
     'closed',


### PR DESCRIPTION
[DBC22-3320](https://moti-imb.atlassian.net/browse/DBC22-3320)

When we build the update dictionary, we are passing in null value(instead of missing key for default value) for event_sub_type which can only be a string. This will cause the event to be deleted every other run as if the event didn't exist in the data API, which will then cause update emails to be repeated every other call as the event gets re-created again after deletion from the last call.

Since we're not using the value anywhere on the front end or backend, I've opted to remove this from the update attribute list altogether.