### PR TITLE
DBC22-3349: Avoided to show camera icon when page refreshed

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -203,9 +203,11 @@ export default function DriveBCMap(props) {
     const interval = setInterval(() => {
       if (referenceFeature) {
         referenceFeature.set('clicked', true);
-        referenceFeature.setStyle(cameraStyles.active);
-        updateClickedFeature(referenceFeature);
-        clearInterval(interval);
+        if (clickedFeature !== undefined) {
+          referenceFeature.setStyle(cameraStyles.active);
+          updateClickedFeature(referenceFeature);
+          clearInterval(interval);
+        }     
       }
     }, 200);
 


### PR DESCRIPTION
DBC22-3349: Avoided to show camera icon when page refreshed.
This fix checks if the user is refreshing the page or clicked an icon on the map to show the active icon properly.