### PR TITLE
DBC22-3669: routing layer fixes in cam details page

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -511,7 +511,7 @@ export default function DriveBCMap(props) {
     });
 
     // Remove layer if no route found
-    const routesData = searchedRoutes ? searchedRoutes : null;
+    const routesData = isCamDetail ? [selectedRoute] : searchedRoutes;
     loadLayer(
       mapLayers, mapRef, mapContext,
       'routeLayer', routesData, routesData, 6, selectedRoute, updateReferenceFeature
@@ -685,7 +685,7 @@ export default function DriveBCMap(props) {
   /* Constants for conditional rendering */
   // Disable cam panel in details page
   const disablePanel = isCamDetail && clickedFeature && clickedFeature.get('type') === 'camera';
-  const openPanel = (!!clickedFeature || !!searchedRoutes) && !disablePanel;
+  const openPanel = (!!clickedFeature || (!!searchedRoutes && !isCamDetail)) && !disablePanel;
   const smallScreen = useMediaQuery('only screen and (max-width: 767px)');
 
   // Reset search params when panel is closed
@@ -703,6 +703,10 @@ export default function DriveBCMap(props) {
   /* Rendering */
   return (
     <div className={`map-container ${isCamDetail ? 'preview' : ''}`}>
+      {searchedRoutes &&
+        <DistanceLabels updateRouteDisplay={updateRouteDisplay} mapRef={mapRef} isCamDetail={isCamDetail} />
+      }
+
       {openPanel &&
         <div
           ref={panel}
@@ -732,10 +736,6 @@ export default function DriveBCMap(props) {
           }
 
           <div className="panel-content">
-            {searchedRoutes &&
-              <DistanceLabels updateRouteDisplay={updateRouteDisplay} mapRef={mapRef} />
-            }
-
             {renderPanel(
               clickedFeature && !clickedFeature.get ? advisoriesInView : clickedFeature,
               isCamDetail, smallScreen, mapView

--- a/src/frontend/src/Components/routing/DistanceLabels.js
+++ b/src/frontend/src/Components/routing/DistanceLabels.js
@@ -21,7 +21,7 @@ import './DistanceLabels.scss';
 export default function DistanceLabels(props) {
   /* initialization */
   // Props
-  const { updateRouteDisplay, mapRef } = props;
+  const { updateRouteDisplay, mapRef, isCamDetail } = props;
 
   // Map not loaded, do nothing
   if (!mapRef || !mapRef.current) {
@@ -29,7 +29,6 @@ export default function DistanceLabels(props) {
   }
 
   // Redux
-  const dispatch = useDispatch();
   const {
     routes: { searchedRoutes, selectedRoute },
 
@@ -61,12 +60,14 @@ export default function DistanceLabels(props) {
   const addDistanceOverlay = (closing=false) => {
     removeOverlays(mapRef);
 
-    const latlngs = searchedRoutes.map((route) => {
+    const routeData = isCamDetail ? [selectedRoute] : searchedRoutes;
+
+    const latlngs = routeData.map((route) => {
       return new LineString((Array.isArray(route.route) ? route.route : route.route.coordinates[0])).getCoordinateAt(0.5);
     });
     const isTooClose = arePointsClose(latlngs);
 
-    searchedRoutes.forEach((route, index) => {
+    routeData.forEach((route, index) => {
       const elem = document.createElement('div');
 
       elem.addEventListener('click', () => {
@@ -77,13 +78,22 @@ export default function DistanceLabels(props) {
 
       const showAsSelected = !closing && compareRoutes(route, selectedRoute);
       elem.className = showAsSelected ? 'distance-overlay selected' : 'distance-overlay';
-      elem.innerHTML = showAsSelected ? `
-        <span class="index-label">${index + 1}</span>
-        <span class="distance-text">${roundedDistance} km</span>
-      ` : `
-        <span class="index-label selected">${index + 1}</span>
-        <span class="distance-text">${roundedDistance} km</span>
-      `;
+      if (routeData.length === 1) {
+        elem.innerHTML = `<span class="distance-text">${roundedDistance} km</span>`;
+
+      } else if (showAsSelected) {
+        elem.innerHTML = `
+          <span class="index-label">${index + 1}</span>
+          <span class="distance-text">${roundedDistance} km</span>
+        `;
+
+      } else {
+        // Inverted selected styling for index bubble
+        elem.innerHTML = `
+          <span class="index-label selected">${index + 1}</span>
+          <span class="distance-text">${roundedDistance} km</span>
+        `;
+      }
 
       const routeLs = new LineString(Array.isArray(route.route) ? route.route : route.route.coordinates[0]);
       let midPointLatLng = routeLs.getCoordinateAt(0.5);


### PR DESCRIPTION
[DBC22-3669](https://moti-imb.atlassian.net/browse/DBC22-3669)

In cam details map:
- Alternate routes no longer renders
- Distance label for alt.route no longer renders, and the only distance label is rendered without index
- Route details panel no longer renders