### PR TITLE
DBC22-3567: zoom out report map when page loaded

### DIFF
--- a/src/frontend/src/Components/map/MapWrapper.js
+++ b/src/frontend/src/Components/map/MapWrapper.js
@@ -137,7 +137,7 @@ export default function MapWrapper(props) {
     const loadFerries = !ferries || (!isInitialLoad.current && mapContext.visible_layers.inlandFerries);
     const loadLocalWeathers = !currentWeathers || (!isInitialLoad.current && mapContext.visible_layers.weather);
     const loadRegionalWeathers = !regionalWeathers || (!isInitialLoad.current && mapContext.visible_layers.weather);
-    const loadRestStops = !loadRestStops || (!isInitialLoad.current && mapContext.visible_layers.restStops);
+    const loadRestStops = !restStops || (!isInitialLoad.current && mapContext.visible_layers.restStops);
 
     // Non-toggleable map layers
     const loadHef = !hef || !isInitialLoad.current;

--- a/src/frontend/src/Components/report/ReportMap.js
+++ b/src/frontend/src/Components/report/ReportMap.js
@@ -223,7 +223,7 @@ export function ReportMap(props) {
           ) {
             const mapCoords = fromLonLat([longitude, latitude]);
 
-            setZoomPan(mapView, 9, mapCoords);
+            setZoomPan(mapView, 6, mapCoords);
             setLocationPin([longitude, latitude], redLocationMarkup, mapRef);
 
             // Wait for map to pan before getting pixel coords


### PR DESCRIPTION
DBC22-3567: zoom out report map when page loaded
The code change also included a fix of loading restStops error. 