### PR TITLE
DBC22-3718: removed duplicated ferries to avoid set styling failure

### DIFF
--- a/src/backend/apps/ferry/views.py
+++ b/src/backend/apps/ferry/views.py
@@ -6,7 +6,7 @@ from rest_framework import viewsets
 
 
 class FerryAPI(CachedListModelMixin):
-    queryset = Ferry.objects.all()
+    queryset = Ferry.objects.distinct('route_id')
     serializer_class = FerryRouteSerializer
     cache_key = CacheKey.FERRY_LIST
     cache_timeout = CacheTimeout.FERRY_LIST

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -590,23 +590,9 @@ export default function DriveBCMap(props) {
   // Ferries layer
   useEffect(() => {
     if (!isCamDetail && ferries && filteredFerries) {
-      const uniqueFerries = ferries.reduce((acc, current) => {
-        if (!acc.some(ferry => ferry.id === current.id)) {
-          acc.push(current);
-        }
-        return acc;
-      }, []);
-
-      const uniqueFilteredFerries = filteredFerries.reduce((acc, current) => {
-        if (!acc.some(ferry => ferry.id === current.id)) {
-          acc.push(current);
-        }
-        return acc;
-      }, []);
-
       loadLayer(
         mapLayers, mapRef, mapContext,
-        'inlandFerries', uniqueFerries, uniqueFilteredFerries, 66,
+        'inlandFerries', ferries, filteredFerries, 66,
         referenceData, updateReferenceFeature, setLoadingLayers
       );
     }

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -589,10 +589,24 @@ export default function DriveBCMap(props) {
 
   // Ferries layer
   useEffect(() => {
-    if (!isCamDetail) {
+    if (!isCamDetail && ferries && filteredFerries) {
+      const uniqueFerries = ferries.reduce((acc, current) => {
+        if (!acc.some(ferry => ferry.id === current.id)) {
+          acc.push(current);
+        }
+        return acc;
+      }, []);
+
+      const uniqueFilteredFerries = filteredFerries.reduce((acc, current) => {
+        if (!acc.some(ferry => ferry.id === current.id)) {
+          acc.push(current);
+        }
+        return acc;
+      }, []);
+
       loadLayer(
         mapLayers, mapRef, mapContext,
-        'inlandFerries', ferries, filteredFerries, 66,
+        'inlandFerries', uniqueFerries, uniqueFilteredFerries, 66,
         referenceData, updateReferenceFeature, setLoadingLayers
       );
     }


### PR DESCRIPTION
DBC22-3718: removed duplicated ferries to avoid set styling failure