### PR TITLE
DBC22-3837: Domain and path redirects

### DIFF
--- a/compose/frontend/Dockerfile
+++ b/compose/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official node runtime as a parent image
-FROM node:19
+FROM node:22-slim
 
 WORKDIR /app/
 RUN chown node:root /app

--- a/compose/frontend/StaticBuild
+++ b/compose/frontend/StaticBuild
@@ -1,5 +1,5 @@
 # Use an official node runtime as a parent image
-FROM node:19 AS buildnode
+FROM node:22-slim AS buildnode
 
 WORKDIR /app/
 RUN chown node:root /app
@@ -32,6 +32,7 @@ RUN touch /run/nginx.pid
 
 COPY ./compose/frontend/default.conf /etc/nginx/conf.d
 COPY ./compose/frontend/default_maintenance.txt /etc/nginx
+COPY ./compose/frontend/legacy_redirects.conf /etc/nginx
 COPY --from=buildnode /app/build /usr/share/nginx/html
 RUN chmod -R 777 /run /var/log/nginx /var/cache/nginx /usr/share/nginx/html/static/js /usr/share/nginx/html/static/css /usr/share/nginx/html/static/media /etc/nginx/conf.d
 

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -48,16 +48,35 @@ map $time_iso8601 $formatted_date {
     '~^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2})'         $year$month$day$hour;
 }
 
-log_format drivebc '$http_x_forwarded_for - $remote_user [$time_local] '
+log_format drivebc '$http_x_forwarded_for - $remote_user [$time_local] "$host" '
                     '"$request" $status $body_bytes_sent '
                     '"$http_referer" "$http_user_agent" $upstream_cache_status "$sent_http_content_type" $request_time';
 
 error_log /var/log/nginx/error.log;
 
+# --- CONSOLIDATED REDIRECTS BLOCK ---
 server {
-    listen       3000;
-    listen  [::]:3000;
-    server_name  localhost;
+    listen 3000;
+    listen [::]:3000;
+
+    # All hostnames that should redirect to www.drivebc.ca
+    server_name drivebc.ca 
+                m.drivebc.ca mobile.drivebc.ca
+                drivebc.com www.drivebc.com
+                drivebc.info www.drivebc.info
+                drivebc.net www.drivebc.net
+                drivebc.org www.drivebc.org;
+    root         /usr/share/nginx/html;
+    access_log /logs/$hostname-$formatted_date-access.log drivebc;
+    server_tokens off;
+    # The action for ALL requests matching this server block: redirect.
+    return 301 https://www.drivebc.ca$request_uri;
+}
+
+server {
+    listen       3000 default_server;
+    listen  [::]:3000 default_server;
+    server_name  www.drivebc.ca; 
     root         /usr/share/nginx/html;
     access_log /logs/$hostname-$formatted_date-access.log drivebc;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -155,4 +155,7 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
+
+    # 301 redirects for legacy backwards-compatibility
+    include legacy_redirects.conf;
 }

--- a/compose/frontend/legacy_redirects.conf
+++ b/compose/frontend/legacy_redirects.conf
@@ -1,0 +1,19 @@
+location ~ ^/cvrp/?$ {
+    return 301 https://twm.th.gov.bc.ca/?c=hct;
+}
+
+location ~ ^/rahp/?$ {
+    return 301 https://$http_host/highway-problem;
+}
+
+location ~ ^/mobile/.*$ {
+    return 301 https://$http_host/;
+}
+
+location ~ ^/directions.html$ {
+    return 301 https://$http_host/;
+}
+
+location ~ ^/chainup.php$ {
+    return 301 https://$http_host/?type=route&layers=chainups;
+}

--- a/compose/openshiftjobs/scripts/analyzeexportlogs.sh
+++ b/compose/openshiftjobs/scripts/analyzeexportlogs.sh
@@ -75,7 +75,7 @@ if [ ${#zipped_files[@]} -gt 0 ]; then
 
     #Run goaccess on all the log files from the date entered
     goaccess_report_name="${CLUSTER}_${start_time_formatted}-goaccess_report.html"
-    zcat "${zipped_files[@]}" | grep -v '^-\s' | goaccess - -o "$goaccess_report_name" --log-format='~h{, } %e %^[%x] "%r" %s %b "%R" "%u" %C "%M" %T' --datetime-format='%d/%b/%Y:%H:%M:%S %z' --ignore-panel=REMOTE_USER --ignore-panel=ASN --tz=America/Vancouver --jobs=2 --geoip-database=$mmdb_file
+    zcat "${zipped_files[@]}" | grep -v '^-\s' | sed 's/] "GET/] "" "GET/g' | sed 's/] "POST/] "" "POST/g' | goaccess - -o "$goaccess_report_name" --log-format='~h{, } %e %^[%x] "%r" %s %b "%R" "%u" %C "%M" %T' --datetime-format='%d/%b/%Y:%H:%M:%S %z' --ignore-panel=REMOTE_USER --ignore-panel=ASN --tz=America/Vancouver --jobs=2 --geoip-database=$mmdb_file
     echo "GoAccess report generated successfully at $goaccess_report_name"
 
     # Get the start date formated in YYYY/MM/DD format

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -39,13 +39,13 @@ DriveBC.ca has a number of components that make up the site
 1. Login to oc for the environment
 1. Confirm your project and cluster by running `oc project`
 1. Navigate to the infrastructure folder in your CLI
-1. `helm install ENV-drivebc -f ./helm/values-ENV.yaml ./helm`
+1. `helm install ENV-drivebc -f ./main/values-ENV.yaml ./main`
 1. Confirm the site is working as expected
 
 #### Gold DR
 To setup site in Gold ensure the DB is running there in Standby and:
 1. `oc project` to confirm you are in GOLD DR on the correct project
-1. `helm install ENV-drivebc -f ./helm/values-ENV.yaml -f ./helm/values-ENV-dr.yaml ./helm`
+1. `helm install ENV-drivebc -f ./main/values-ENV.yaml -f ./main/values-ENV-dr.yaml ./main`
 1. Validate the site is working as expected
 
 #### Other tasks:
@@ -58,6 +58,6 @@ To setup site in Gold ensure the DB is running there in Standby and:
 Once the site is setup the Github actions should be able to handle most helm upgrades, but if you want to do do one manually (ie for testing) it's very similar to initial setup
 1. `oc project` to confirm the project and cluster
 1. `helm list` if you want to confirm the project is there already
-1. GOLD `helm install ENV-drivebc -f ./helm/values-ENV.yaml -f ./helm`
-1. GOLDDR: `helm install ENV-drivebc -f ./helm/values-ENV.yaml -f ./helm/values-ENV-dr.yaml ./helm`
+1. GOLD `helm upgrade ENV-drivebc -f ./main/values-ENV.yaml ./main`
+1. GOLDDR: `helm upgrade ENV-drivebc -f ./main/values-ENV.yaml -f ./main/values-ENV-dr.yaml ./main`
     - NOTE: If you want to set a specific tag instead of the default, you can add `--set django.image.tag=TAG` (doing same for static, tasks, redis, openshiftjobs)

--- a/infrastructure/main/charts/static/templates/static-route.yaml
+++ b/infrastructure/main/charts/static/templates/static-route.yaml
@@ -28,7 +28,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
-    {{ if .Values.route.iprestrictedAdminPages }}
+    {{ if .Values.route.iprestricted }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}
 spec:
@@ -42,4 +42,47 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None
+{{- end }}
+
+---
+{{- if .Values.route.vanityurl.extravanityurlhost }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "app.fullname" . }}-frontend-nonwww-vanityurl
+  labels: {{ include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    {{ if .Values.route.iprestricted }}
+    haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
+    {{ end }}
+spec:
+  host: {{ .Values.route.vanityurl.extravanityurlhost  }}
+  to:
+    kind: Service
+    name: {{ template "app.fullname" . }}-frontend
+  port:
+    targetPort: 3000
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}
+---
+{{- if .Values.route.redirecthosts }}
+{{- range .Values.route.redirecthosts }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "app.fullname" $ }}-{{ . | replace "." "-" }}-redirect
+spec:
+  host: {{ . }}
+  to:
+    kind: Service
+    name: {{ template "app.fullname" $ }}-frontend
+  port:
+    targetPort: 3000
+  wildcardPolicy: None
+---
+{{- end }}
 {{- end }}

--- a/infrastructure/main/values-dev.yaml
+++ b/infrastructure/main/values-dev.yaml
@@ -137,6 +137,8 @@ static:
     vanityurl: 
       enabled: true
       vanityurlhost: dev.drivebc.ca
+      extravanityurlhost: # PROD ONLY: Set to drivebc.ca. This will create an extra vanityurl route that has a redirect to www.drivebc.ca
+    redirecthosts: # Mostly for the prod site. These will all redirect to www.drivebc.ca
   logpvc:
     storage: 1Gi
   podDisruptionBudget: 

--- a/infrastructure/main/values-prod.yaml
+++ b/infrastructure/main/values-prod.yaml
@@ -136,7 +136,19 @@ static:
     iprestricted: false  #Set to true if you want to limit IP's the the addresses in the ipallowlist 
     vanityurl: 
       enabled: true
-      vanityurlhost: www.drivebc.ca
+      vanityurlhost: www.drivebc.ca # should be the www.drivebc.ca url
+      extravanityurlhost: drivebc.ca # PROD ONLY: Set to drivebc.ca. This will create an extra vanityurl route that has a redirect to www.drivebc.ca
+    redirecthosts: # Mostly for the prod site. These will all redirect to www.drivebc.ca
+      - www.drivebc.com
+      - drivebc.com
+      - www.drivebc.info
+      - drivebc.info
+      - www.drivebc.net
+      - drivebc.net
+      - www.drivebc.org
+      - drivebc.org
+      - m.drivebc.ca
+      - mobile.drivebc.ca
   logpvc:
     storage: 2Gi
   podDisruptionBudget: 

--- a/infrastructure/main/values-test.yaml
+++ b/infrastructure/main/values-test.yaml
@@ -137,6 +137,8 @@ static:
     vanityurl: 
       enabled: true
       vanityurlhost: tst.drivebc.ca
+      extravanityurlhost: # PROD ONLY: Set to drivebc.ca. This will create an extra vanityurl route that has a redirect to www.drivebc.ca
+    redirecthosts: # Mostly for the prod site. These will all redirect to www.drivebc.ca
   logpvc:
     storage: 1Gi
   podDisruptionBudget: 

--- a/infrastructure/main/values-uat.yaml
+++ b/infrastructure/main/values-uat.yaml
@@ -137,6 +137,8 @@ static:
     vanityurl: 
       enabled: true
       vanityurlhost: uat.drivebc.ca
+      extravanityurlhost: # PROD ONLY: Set to drivebc.ca. This will create an extra vanityurl route that has a redirect to www.drivebc.ca
+    redirecthosts: # Mostly for the prod site. These will all redirect to www.drivebc.ca
   logpvc:
     storage: 2Gi
   podDisruptionBudget: 


### PR DESCRIPTION
https://moti-imb.atlassian.net/browse/DBC22-3837
This will setup methods to redirect all the .com .info .org .net requests as well as drivebc.ca all to www.drivebc.ca
path redirects include:
/cvrp, /rahp, /mobile, /directions.html, /chainup.php
The chainup redirect currently goes to a url that is not setup yet: https://$http_host/?type=route&layers=chainups. Once we have that this will need to be modified.
I also updated the log format to include $host so we can seem amount of redirects from those domains. Had to update goaccess log format as well with that change.