### PR TITLE
DBC22-3437: Expire cache when backend returns 404

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -97,6 +97,7 @@ server {
         proxy_cache_revalidate on;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
         proxy_cache_valid 200 30s;
+        proxy_cache_valid 404 1s;
         add_header X-Proxy-Cache $upstream_cache_status;
         proxy_cache_bypass $http_cachebypass;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
This fixes the issue where deleted advisories still get results from nginx. Now if the backend returns a 404 it will remove the stale cache object instead of continuing to serve the stale object.