### PR TITLE
DBC22-3837: Fix mobile legacy redirect

### DIFF
--- a/compose/frontend/legacy_redirects.conf
+++ b/compose/frontend/legacy_redirects.conf
@@ -6,7 +6,7 @@ location ~ ^/rahp/?$ {
     return 301 https://$http_host/highway-problem;
 }
 
-location ~ ^/mobile/.*$ {
+location ~ ^/(mobile/.*|mobile)$ {
     return 301 https://$http_host/;
 }
 


### PR DESCRIPTION
Fix regex for /mobile redirect so it matches on /mobile and /mobile/<...>