### PR TITLE
DBC22-3855: separated useEffect on searchLocationFrom and searchLocationTo

### DIFF
--- a/src/frontend/src/Components/routing/RouteSearch.js
+++ b/src/frontend/src/Components/routing/RouteSearch.js
@@ -55,8 +55,7 @@ const RouteSearch = forwardRef((props, ref) => {
   const isInitialMount = useRef(true);
   const isInitialMountSpinner = useRef(true);
 
-  // useEffect hooks
-  useEffect(() => {
+  const updateSearch = () => {
     if (isInitialMount.current) { // Do nothing on first load
       isInitialMount.current = false;
       return;
@@ -70,7 +69,15 @@ const RouteSearch = forwardRef((props, ref) => {
       dispatch(clearSelectedRoute());
       removeOverlays(mapRef);
     }
-  }, [searchLocationFrom, searchLocationTo]);
+  }
+
+  useEffect(() => {
+    updateSearch();
+  }, [searchLocationFrom]);
+
+  useEffect(() => {
+    updateSearch();
+  }, [searchLocationTo]);
 
   useEffect(() => {
     if (isInitialMountSpinner.current) { // Do nothing on first load


### PR DESCRIPTION
DBC22-3855: separated useEffect on searchLocationFrom and searchLocationTo to make sure the hook can be called whenever either of the values was updated.