### PR TITLE
DBC22-3289 BCeID/IDIR Logout

### DIFF
--- a/src/backend/apps/authentication/adapters.py
+++ b/src/backend/apps/authentication/adapters.py
@@ -1,6 +1,12 @@
-from django.conf import settings
+import logging
+
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django.conf import settings
+from django.contrib.auth.signals import user_logged_in
+import requests
+
+logger = logging.getLogger(__name__)
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -10,7 +16,61 @@ class AccountAdapter(DefaultAccountAdapter):
         return settings.FRONTEND_BASE_URL
 
     def get_logout_redirect_url(self, request):
-        if request.path.startswith('/drivebc-'):
-            return '/' + request.path.split('/')[1] + '/'
-        return settings.FRONTEND_BASE_URL
+        redirect_url = settings.FRONTEND_BASE_URL
 
+        # for admin and cms, return users to root admin/cms page
+        if request.path.startswith('/drivebc-'):
+            path = request.path.split('/')[1] + '/'
+
+            # in local dev, admin/cms are coming directly from django
+            if 'localhost' in redirect_url:
+                redirect_url = 'http://localhost:8000/' + path
+            else:
+                redirect_url += path
+
+        url = f'{settings.KEYCLOAK_URL}/protocol/openid-connect/logout'
+
+        token = request.session.get('id_token')
+        if token:
+            url = f'{url}?post_logout_redirect_uri={redirect_url}&id_token_hint={token}'
+            # without the token and redirect_uri, user is logged out and ends on
+            # keycloak "you have signed out" page
+
+        return url
+
+
+def store_id_token(sender, **kwargs):
+    '''
+    Call the keycloak API to refresh the user's access token so we have an
+    id_token to use on logout (stored in the user's session).  Triggered on the
+    `user_logged_in` hook.
+    '''
+
+    user = kwargs.get('user')
+    request = kwargs.get('request')
+
+    if request.session.get('_auth_user_backend') == 'django.contrib.auth.backends.ModelBackend':
+        return
+
+    try:
+        account = user.socialaccount_set.first()
+        token = account.socialtoken_set.first()
+        res = requests.post(
+            f'{settings.KEYCLOAK_URL}/protocol/openid-connect/token',
+            data={
+                'grant_type': 'refresh_token',
+                'client_id': settings.KEYCLOAK_CLIENT_ID,
+                'client_secret': settings.KEYCLOAK_SECRET,
+                'refresh_token': token.token_secret,
+            }
+        )
+        data = res.json()
+        token.token = data.get('access_token')
+        token.token_secret = data.get('refresh_token')
+        token.save()
+        request.session['id_token'] = data.get('id_token')
+    except Exception as e:
+        # failure to store id_token not fatal to logging in
+        logger.exception(e)
+
+user_logged_in.connect(store_id_token, weak=False)

--- a/src/backend/config/settings/django.py
+++ b/src/backend/config/settings/django.py
@@ -89,8 +89,8 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 LOGIN_REDIRECT_URL = FRONTEND_BASE_URL
-LOGIN_URL = (FRONTEND_BASE_URL +
-             'accounts/oidc/idir/login/?process=login&next=%2Fdrivebc-admin%2F&auth_params=kc_idp_hint=azureidir')
+IDIR_LOGIN_PATH = 'accounts/oidc/idir/login/?process=login&next=%2Fdrivebc-admin%2F&auth_params=kc_idp_hint=azureidir'
+LOGIN_URL = (('http://localhost:8000/' if 'localhost' in FRONTEND_BASE_URL else FRONTEND_BASE_URL) + IDIR_LOGIN_PATH)
 
 # Language
 USE_I18N = False

--- a/src/backend/config/settings/third_party.py
+++ b/src/backend/config/settings/third_party.py
@@ -49,6 +49,10 @@ if os.name == "nt":
     GDAL_LIBRARY_PATH = env("GDAL_LIBRARY_PATH")
 
 # Allauth
+KEYCLOAK_CLIENT_ID = env("BCEID_CLIENT_ID")
+KEYCLOAK_SECRET = env("BCEID_SECRET")
+KEYCLOAK_URL = env("BCEID_URL")
+
 ACCOUNT_ADAPTER = 'apps.authentication.adapters.AccountAdapter'
 
 # need our own adapter to override various redirect url methods following
@@ -60,27 +64,34 @@ SOCIALACCOUNT_PROVIDERS = {
             {
                 'provider_id': 'bceid',
                 'name': 'BCeID via Keycloak',
-                'client_id': env("BCEID_CLIENT_ID"),
-                'secret': env("BCEID_SECRET"),
+                'client_id': KEYCLOAK_CLIENT_ID,
+                'secret': KEYCLOAK_SECRET,
                 'settings': {
-                    'server_url': env("BCEID_URL"),
+                    'server_url': KEYCLOAK_URL,
                 },
             },
             {
                 'provider_id': 'idir',
                 'name': 'Azure IDIR via Keycloak',
-                'client_id': env("BCEID_CLIENT_ID"),
-                'secret': env("BCEID_SECRET"),
+                'client_id': KEYCLOAK_CLIENT_ID,
+                'secret': KEYCLOAK_SECRET,
                 'settings': {
-                    'server_url': env("BCEID_URL"),
+                    'server_url': KEYCLOAK_URL,
                 },
             },
         ],
         'AUTH_PARAMS': {
             'kc_idp_hint': 'bceidbasic',
         },
+        'EMAIL_AUTHENTICATION_AUTO_CONNECT': True,
+        'EMAIL_AUTHENTICATION': True,
+        'STORE_TOKENS': True,
     },
 }
 
-SOCIALACCOUNT_EMAIL_VERIFICATION = 'none'
-SOCIALACCOUNT_LOGIN_ON_GET = True
+# SOCIALACCOUNT_ADAPTER = 'apps.authentication.adapters.SocialAccountAdapter'
+SOCIALACCOUNT_LOGIN_ON_GET = False
+SOCIALACCOUNT_EMAIL_VERIFICATION = False
+SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+SOCIALACCOUNT_STORE_TOKENS = True

--- a/src/backend/config/urls.py
+++ b/src/backend/config/urls.py
@@ -1,4 +1,5 @@
 from allauth.account.decorators import secure_admin_login
+from allauth.account import views
 from django.conf import settings
 from django.conf.urls import handler403, defaults
 from django.contrib import admin
@@ -51,6 +52,7 @@ admin.autodiscover()
 
 if settings.FORCE_IDIR_AUTHENTICATION:
     admin.site.login = secure_admin_login(admin.site.login)
+    admin.site.logout = views.logout
     handler403 = permission_denied_handler
 
 

--- a/src/backend/templates/socialaccount/login.html
+++ b/src/backend/templates/socialaccount/login.html
@@ -1,0 +1,30 @@
+{% extends "admin/login.html" %}
+
+{% load allauth %}
+
+{% block head_title %}Sign In{% endblock head_title %}
+
+{% block branding %}
+    <h1>
+        DriveBC {% if 'cms' in request.GET.next %}CMS{% else %}Administration{% endif %}
+    </h1>
+{% endblock %}
+
+{% block content %}
+    {% element h1 %}Sign In Via {{ provider }}{% endelement %}
+
+    {% element p %}
+        You need to sign in with an IDIR account to access this part of the site.
+    {% endelement %}
+
+    {% element form method="post" no_visible_fields=True %}
+        {% slot actions %}
+            {% csrf_token %}
+            <div style="text-align: center">
+                <button type="submit" class="button" style="padding: 0.5rem 1rem; font-size: larger">
+                    Continue to Keycloak
+                </button>
+            </div>
+        {% endslot %}
+    {% endelement %}
+{% endblock content %}


### PR DESCRIPTION
This change enables the use of Keycloak's logout endpoint to kill a user's BCeID/IDIR session at Keycloak, so that on signing into the site again, the user is again challenged for credentials.