### PR TITLE
DBC22-2259: added display_category to event diff fields to avoid future events can't be updated

### DIFF
--- a/src/backend/apps/event/enums.py
+++ b/src/backend/apps/event/enums.py
@@ -101,7 +101,8 @@ EVENT_DIFF_FIELDS = [
     'schedule',
     'start',
     'end',
-    'closed'
+    'closed',
+    'display_category',
 ]
 
 EVENT_UPDATE_FIELDS = [


### PR DESCRIPTION
DBC22-2259: added display_category to event diff fields to avoid future events can't be updated