### PR TITLE
DBC22-2830 RAHP Map not visible in landscape

### DIFF
--- a/src/frontend/src/Components/report/ReportMap.scss
+++ b/src/frontend/src/Components/report/ReportMap.scss
@@ -121,6 +121,7 @@
     padding-top: 0;
     padding-bottom: 0;
     height: auto;
+    min-height: 250px;
 
     @media (max-width: 767px) {
       padding: 0;


### PR DESCRIPTION
Fixes the map not being visible in RAHP maps when user is on mobile in landscape mode.  Caused because page is too short to display map with auto height, so map doesn't render, so page height is not increased to include map.  Fixed by adding min-height to map-wrapper.