### PR TITLE
DBC22-4015 Delays list not reflecting changed filters on load

### DIFF
--- a/src/frontend/src/Components/shared/Filters.js
+++ b/src/frontend/src/Components/shared/Filters.js
@@ -129,15 +129,15 @@ export default function Filters(props) {
       mapLayers.current[layer].setVisible(checked);
     }
 
-    // Run callback for event list, non-line layers
-    if (callback && runCallback) {
-      callback(layer, checked);
-    }
-
-    // Set context and local storage
-    mapContext.visible_layers[layer] = checked;
-    setMapContext(mapContext);
-    localStorage.setItem('mapContext', JSON.stringify(mapContext));
+    // Update context and local storage
+    const newMapContext = {
+      visible_layers: {
+        ...mapContext.visible_layers,
+        [layer]: checked,
+      }
+    };
+    setMapContext(newMapContext);
+    localStorage.setItem('mapContext', JSON.stringify(newMapContext));
   }
 
   // Set focus on filters with a blur out after 1 second

--- a/src/frontend/src/pages/EventsListPage.js
+++ b/src/frontend/src/pages/EventsListPage.js
@@ -103,7 +103,7 @@ export default function EventsListPage() {
   const { headerHeightContext } = useContext(HeaderHeightContext);
 
   // States
-  const getDefaultFilterState = () => {
+  const getFilterState = () => {
     if (searchParams.get('chainUpsOnly') === 'true') {
       return {
         'closures': false,
@@ -124,7 +124,7 @@ export default function EventsListPage() {
   }
 
   const [sortingKey, setSortingKey] = useState(selectedRoute && selectedRoute.routeFound ? 'route_order' : (localStorage.getItem('sorting-key')? localStorage.getItem('sorting-key') : 'severity_desc'));
-  const [eventCategoryFilter, setEventCategoryFilter] = useState(getDefaultFilterState());
+  const [eventCategoryFilter, setEventCategoryFilter] = useState(getFilterState());
   const [processedEvents, setProcessedEvents] = useState([]); // Nulls for mapping loader
   const [trackedEvents, setTrackedEvents] = useState({}); // Track event updates between refreshes
   const [showLoader, setShowLoader] = useState(true);
@@ -435,12 +435,10 @@ export default function EventsListPage() {
   }, [processedEvents, trackedEvents]);
 
   // Handlers
-  const toggleEventCategoryFilter = (targetCategory, check) => {
-    const newFilter = {...eventCategoryFilter};
-    newFilter[targetCategory] = check;
 
-    setEventCategoryFilter(newFilter);
-  };
+  useEffect(() => {
+    setEventCategoryFilter(getFilterState());
+  }, [mapContext]);
 
   const handleRoute = (event) => {
     trackEvent('click', 'event', 'events list page', event.event_type, event.event_sub_type);
@@ -591,7 +589,6 @@ export default function EventsListPage() {
                     <div className="type filter-option-btn">
 
                       <Filters
-                        callback={toggleEventCategoryFilter}
                         disableFeatures={true}
                         enableRoadConditions={false}
                         enableChainUps={true}


### PR DESCRIPTION
Use of callback in Filter and events list was creating a race condition causing filter state to be out of sync in the events list.  Removed callback mechanism (not used elsewhere) and changed event list to use mapContext, and for Filter to update mapcontext in a way reflecting nested changes.