### PR TITLE
DBC22-3289 BCEID not routing through logout

### DIFF
--- a/src/frontend/src/Modal.js
+++ b/src/frontend/src/Modal.js
@@ -149,7 +149,6 @@ export default function Modal() {
           { authContext.action === 'Sign Out' &&
             <form method='post' action={`${window.API_HOST}/accounts/logout/`} onSubmit={handleSubmit}>
               <input type='hidden' name='csrfmiddlewaretoken' value={getCookie('csrftoken')} />
-              <input type='hidden' name='next' value={window.location.href} />
               <button type='submit' className="btn btn-outline-primary">Sign out of DriveBC</button>
             </form>
           }


### PR DESCRIPTION
The presence of a `next` parameter in the sign out form was preventing the call to .get_redirect_logout_url, which sends the user to the auth server to have their session terminated.