### PR TITLE
DBC22-4132 Cam panel not updating

### DIFF
--- a/src/frontend/src/Components/map/panels/CamPanel.js
+++ b/src/frontend/src/Components/map/panels/CamPanel.js
@@ -270,7 +270,7 @@ export default function CamPanel(props) {
                   </div>
                 )}
 
-                <img ref={imageRef} src={getCamLink(camera)} width="300" />
+                <img ref={imageRef} src={getCamLink(camera)} width="300" data-current="0" />
 
                 {camera.marked_delayed && camera.marked_stale && (
                   <>


### PR DESCRIPTION
Automatically updating the image (and triggering the updated message) requires the image to have a data attribute set to the current camIndex.  This attribute was not being set on initially viewing the camera because the useEffect for setting it when camIndex changes was not being executed.  Hard coding the initial index to 0 (the default state for camIndex) resolves the issue.