### PR TITLE
DBC22-4280: Fix site asset caching

### DIFF
--- a/compose/frontend/StaticBuild
+++ b/compose/frontend/StaticBuild
@@ -33,6 +33,7 @@ RUN touch /run/nginx.pid
 COPY ./compose/frontend/default.conf /etc/nginx/conf.d
 COPY ./compose/frontend/default_maintenance.txt /etc/nginx
 COPY ./compose/frontend/legacy_redirects.conf /etc/nginx
+COPY ./compose/frontend/security_headers.conf /etc/nginx/conf.d
 COPY --from=buildnode /app/build /usr/share/nginx/html
 RUN chmod -R 777 /run /var/log/nginx /var/cache/nginx /usr/share/nginx/html/static/js /usr/share/nginx/html/static/css /usr/share/nginx/html/static/media /etc/nginx/conf.d
 

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -81,15 +81,15 @@ server {
     server_name  www.drivebc.ca; 
     root         /usr/share/nginx/html;
     access_log /logs/$hostname-$formatted_date-access.log drivebc;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Permissions-Policy "geolocation=(self), fullscreen=*";
-    add_header X-Content-Type-Options "nosniff";
-    add_header X-Robots-Tag "noindex";
-    
-    # Add Content Security Policy header
-    add_header Content-Security-Policy "default-src 'self' https://*.arcgis.com https://*.gov.bc.ca https://*.drivebc.ca https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ data: https://*.flickr.com https://*.staticflickr.com https://www.youtube.com https://*.ytimg.com; script-src 'self' https://*.gov.bc.ca https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://*.flickr.com https://*.staticflickr.com 'unsafe-inline'; style-src 'self' https://*.flickr.com https://*.staticflickr.com 'unsafe-inline'; frame-src https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/; frame-ancestors 'self'; form-action 'self' *.gov.bc.ca/ https://*.drivebc.ca";
-
     server_tokens off;
+    include /etc/nginx/conf.d/security_headers.conf;
+
+    location ~* \.(?:css|js|woff|woff2|ttf|eot|svg|png|jpe?g|gif|ico)$ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+        gzip_static on;
+        include /etc/nginx/conf.d/security_headers.conf;
+    }
 
     location / {
         index  index.html index.htm;
@@ -97,17 +97,17 @@ server {
         gzip_static on; 
     }
 
-    location /images/ {
+    location ^~ /images/ {
         alias /app/images/webcams/;
         try_files $uri =404;
         expires    modified +1s;
         add_header Last-Modified "";
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        include /etc/nginx/conf.d/security_headers.conf;
     }
 
     # Caching data from the API
-    location /api/ {
-        proxy_ignore_headers Vary; #DBC22-2067 - Review prior to adding site personalization
+    location ^~ /api/ {
+        proxy_ignore_headers Vary; # The Vary headers from the backend prevents proper caching
         proxy_ssl_server_name on;
         proxy_pass http://{ENVIRONMENT}-django;
         proxy_connect_timeout 5s;
@@ -121,34 +121,34 @@ server {
         proxy_cache_valid 404 1s;
         add_header X-Proxy-Cache $upstream_cache_status;
         proxy_cache_bypass $http_cachebypass;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        include /etc/nginx/conf.d/security_headers.conf;
     }
 
-    location /api/users/ {
+    location ^~ /api/users/ {
         proxy_ssl_server_name on;
         proxy_pass http://{ENVIRONMENT}-django;
         proxy_connect_timeout 10s;
         proxy_set_header Host $host;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        include /etc/nginx/conf.d/security_headers.conf;
     }
 
-    location /api/session {
+    location ^~ /api/session {
         proxy_ssl_server_name on;
         proxy_pass http://{ENVIRONMENT}-django;
         proxy_connect_timeout 10s;
         proxy_set_header Host $host;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        include /etc/nginx/conf.d/security_headers.conf;
     }
 
-    location /accounts/ {
+    location ^~ /accounts/ {
         proxy_ssl_server_name on;
         proxy_pass http://{ENVIRONMENT}-django;
         proxy_connect_timeout 10s;
         proxy_set_header Host $host;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        include /etc/nginx/conf.d/security_headers.conf;
     }
 
-    location /django-media/ {
+    location ^~ /django-media/ {
         proxy_ssl_server_name on;
         proxy_pass http://{ENVIRONMENT}-django;
         proxy_connect_timeout 5s;
@@ -161,9 +161,9 @@ server {
         proxy_cache_valid 200 1d;
         add_header X-Proxy-Cache $upstream_cache_status;
         proxy_cache_bypass $http_cachebypass;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        include /etc/nginx/conf.d/security_headers.conf;
     }
-    location /healthz {
+    location ^~ /healthz {
         access_log off;
         add_header 'Content-Type' 'text/plain';
     	allow 127.0.0.1;

--- a/compose/frontend/entrypoint
+++ b/compose/frontend/entrypoint
@@ -40,7 +40,7 @@ sed -i "s~{ENVIRONMENT}~$ENVIRONMENT~g" /etc/nginx/conf.d/default.conf
 # Check if the environment is 'prod' so that we remove the noindex header
 if [ "$ENVIRONMENT" = "prod-drivebc" ]; then
     echo "Environment is 'prod' removing X-Robots-Tag noindex header."
-    sed -i '/add_header X-Robots-Tag "noindex";/d' /etc/nginx/conf.d/default.conf
+    sed -i '/add_header X-Robots-Tag "noindex";/d' /etc/nginx/conf.d/security_headers.conf
 else
     echo "Environment is not 'prod', keeping X-Robots-Tag noindex header."
 fi

--- a/compose/frontend/security_headers.conf
+++ b/compose/frontend/security_headers.conf
@@ -1,0 +1,5 @@
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header Permissions-Policy "geolocation=(self), fullscreen=*";
+add_header X-Content-Type-Options "nosniff";
+add_header X-Robots-Tag "noindex";
+add_header Content-Security-Policy "default-src 'self' https://*.arcgis.com https://*.gov.bc.ca https://*.drivebc.ca https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ data: https://*.flickr.com https://*.staticflickr.com https://www.youtube.com https://*.ytimg.com; script-src 'self' https://*.gov.bc.ca https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://*.flickr.com https://*.staticflickr.com 'unsafe-inline'; style-src 'self' https://*.flickr.com https://*.staticflickr.com 'unsafe-inline'; frame-src https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/; frame-ancestors 'self'; form-action 'self' *.gov.bc.ca/ https://*.drivebc.ca";

--- a/infrastructure/main/charts/django/templates/django-route.yaml
+++ b/infrastructure/main/charts/django/templates/django-route.yaml
@@ -3,10 +3,11 @@ kind: Route
 metadata:
   name: {{ template "app.fullname" . }}-backend
   labels: {{ include "app.labels" . | nindent 4 }}
-{{ if .Values.route.iprestrictedAdminPages }}
   annotations:
+    {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
-{{ end }}
+    {{ end }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
 spec:
   to:
     kind: Service
@@ -26,10 +27,11 @@ kind: Route
 metadata:
   name: {{ template "app.fullname" . }}-backend-static
   labels: {{ include "app.labels" . | nindent 4 }}
-{{ if .Values.route.iprestrictedAdminPages }}
   annotations:
+    {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
-{{ end }}
+    {{ end }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
 spec:
   to:
     kind: Service
@@ -49,10 +51,11 @@ kind: Route
 metadata:
   name: {{ template "app.fullname" . }}-admin
   labels: {{ include "app.labels" . | nindent 4 }}
-{{ if .Values.route.iprestrictedAdminPages }}
   annotations:
+    {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
-{{ end }}
+    {{ end }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
 spec:
   to:
     kind: Service
@@ -72,10 +75,11 @@ kind: Route
 metadata:
   name: {{ template "app.fullname" . }}-healthcheck
   labels: {{ include "app.labels" . | nindent 4 }}
-{{ if .Values.route.iprestrictedAdminPages }}
   annotations:
+    {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
-{{ end }}
+    {{ end }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
 spec:
   to:
     kind: Service
@@ -100,6 +104,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
+    haproxy.router.openshift.io/disable_cookies: 'true'
     {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}
@@ -124,6 +129,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
+    haproxy.router.openshift.io/disable_cookies: 'true'
     {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}
@@ -148,6 +154,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
+    haproxy.router.openshift.io/disable_cookies: 'true'
     {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}
@@ -172,6 +179,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
+    haproxy.router.openshift.io/disable_cookies: 'true'
     {{ if .Values.route.iprestrictedAdminPages }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}

--- a/infrastructure/main/charts/static/templates/static-route.yaml
+++ b/infrastructure/main/charts/static/templates/static-route.yaml
@@ -3,10 +3,11 @@ kind: Route
 metadata:
   name: {{ template "app.fullname" . }}-frontend
   labels: {{ include "app.labels" . | nindent 4 }}
-{{ if .Values.route.iprestricted }}
   annotations:
+    {{ if .Values.route.iprestricted }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
-{{ end }}
+    {{ end }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
 spec:
   host: {{ .Values.route.host  }} 
   to:
@@ -28,6 +29,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
+    haproxy.router.openshift.io/disable_cookies: 'true'
     {{ if .Values.route.iprestricted }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}
@@ -53,6 +55,7 @@ metadata:
   labels: {{ include "app.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
+    haproxy.router.openshift.io/disable_cookies: 'true'
     {{ if .Values.route.iprestricted }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.global.route.ipallowlist  }}
     {{ end }}
@@ -75,6 +78,9 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ template "app.fullname" $ }}-{{ . | replace "." "-" }}-redirect
+  labels: {{ include "app.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: 'true'
 spec:
   host: {{ . }}
   to:


### PR DESCRIPTION
https://moti-imb.atlassian.net/browse/DBC22-4280
Static site assets had a cookie applied and set to private caching. This was set by the HA proxy so that you get sticky sessions. In our application that doesn't really matter.

In addition, I updated the nginx config to automatically cache the static site assets for 7 days. 

We were seeing a lot of excess hits on static site assets. Basically each user was downloading the files daily at least.