### PR TITLE
DBC22-4324: Update caching header for index.html

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -91,6 +91,12 @@ server {
         include /etc/nginx/conf.d/security_headers.conf;
     }
 
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate, max-age=0";
+        expires off;
+        include /etc/nginx/conf.d/security_headers.conf;
+    }
+
     location / {
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
This fixes an issue where it was up to the browser to determine how long to keep index.html in cache.
This sometimes caused issues during releases because a browser may have cached the file, but now main.js and the other files don't work anymore which would prevent the user from using the site.
This updated header sets `cache-control: no-cache, must-revalidate, max-age=0` so that the browser will revalidate it on each load. Typically it will just get a 304, but if there are changes it will pull down the new file.

NOTE: I would release this change on it's own before the next release so that when we do the next release we don't break the site for users that had the file cached.