### PR TITLE
DBC22-5104: fixed crash issue when editing emergency alert

### DIFF
--- a/src/backend/apps/cms/wagtail_hooks.py
+++ b/src/backend/apps/cms/wagtail_hooks.py
@@ -170,6 +170,8 @@ class CopyPreviewURLMenuItem(ActionMenuItem):
             preview_url = f"{base_url}advisories/{page.slug}?preview=true"
         elif isinstance(page, Bulletin):
             preview_url = f"{base_url}bulletins/{page.slug}?preview=true"
+        else:
+            return ""
 
         # Match Wagtail's built-in action menu structure
         return format_html(


### PR DESCRIPTION
Return nothing for the preview url button when the page is not Advisory or Bulletin.