### PR TITLE
DBC22-1527: Remove temp hostAliases

### DIFF
--- a/infrastructure/main/charts/tasks/templates/tasks-deployment.yaml
+++ b/infrastructure/main/charts/tasks/templates/tasks-deployment.yaml
@@ -41,10 +41,6 @@ spec:
         - name: django-app-images-volume
           persistentVolumeClaim:
             claimName: {{ .Values.deployment.volumes.claimName  }}
-      hostAliases: # DBC22-1527: This is a temporary workaround due to the fact that we can only access this IP for DIT from Gold.
-        - ip: 142.34.81.128
-          hostnames:
-            - dit.th.gov.bc.ca
       containers:
         - resources:
             requests:


### PR DESCRIPTION
The network bug has been fixed in OpenShift Gold so this is no longer required.