### PR TITLE
DBC22-5189 Correct camera not selected from details page link

### DIFF
--- a/src/frontend/src/pages/CameraDetailsPage.js
+++ b/src/frontend/src/pages/CameraDetailsPage.js
@@ -315,12 +315,13 @@ export default function CameraDetailsPage() {
     setReplay(!replay);
   };
 
-  const mapViewRoute = () => {
+  const mapViewRoute = (id) => {
     navigate({
       pathname: '/',
       search: `?${createSearchParams({
         type: "camera",
-        id: camera.id,
+        camIndex: [...cameraGroupRefs.current].indexOf(id),
+        id,
       })}`
     });
   };
@@ -811,7 +812,7 @@ export default function CameraDetailsPage() {
                                   referenceData={referenceData}
                                   rootCamera={camera}
                                   isCamDetail={true}
-                                  mapViewRoute={mapViewRoute}
+                                  mapViewRoute={() => mapViewRoute(camera.id)}
                                   loadCamDetails={loadCamDetails}
                                 />
                               }
@@ -1090,7 +1091,7 @@ export default function CameraDetailsPage() {
                                         referenceData={referenceData}
                                         rootCamera={camera}
                                         isCamDetail={true}
-                                        mapViewRoute={mapViewRoute}
+                                        mapViewRoute={() => mapViewRoute(camera.id)}
                                         loadCamDetails={loadCamDetails}
                                       />
                                     }

--- a/src/frontend/src/pages/MapPage.js
+++ b/src/frontend/src/pages/MapPage.js
@@ -117,9 +117,6 @@ export default function MapPage() {
   return (
     <DndProvider options={HTML5toTouch}>
       <div className="map-page map-wrap">
-        {/* Need this to show alert above Map; duplicates App level alert which is hidden by map */}
-        {/* <EmergencyAlert /> */}
-
         {referenceData &&
           <MapWrapper referenceData={referenceData} />
         }


### PR DESCRIPTION
The "view on map" link on the details page was not including a CamIndex parameter, so switching to map view reset to the default camera.  Adding that parameter fixed the bug.