### PR TITLE
DBC22-5183 Showing route on route details in small screen

### DIFF
--- a/src/frontend/src/Components/shared/header/Header.js
+++ b/src/frontend/src/Components/shared/header/Header.js
@@ -226,7 +226,7 @@ export default function Header() {
               </button>
             }
 
-            {smallScreen && showSearch && !openSearch && selectedRoute && isNavbarCollapsed && !showRouteObjs &&
+            {smallScreen && showSearch && !openSearch && selectedRoute && isNavbarCollapsed &&
               <button
                 className={`searched-route btn show`}
                 aria-label="searched route"


### PR DESCRIPTION
A flag on showRouteObjs was preventing the search boxes from appearing on small screens when in route detail.  Removed that check, so the route start/end shows on both routes and route details.