### PR TITLE
DBC22-4961 campanel directional button error after updated image

### DIFF
--- a/src/frontend/src/Components/map/panels/CamPanel.js
+++ b/src/frontend/src/Components/map/panels/CamPanel.js
@@ -148,8 +148,9 @@ export default function CamPanel(props) {
     const nextIndex = (currentIndex + 1) % buttons.length;
     buttons[nextIndex].focus();
     setActiveIndex(nextIndex);
-    const nextCamera = camera.camGroup[nextIndex];
+    const nextCamera = camFeature.getProperties().camGroup[nextIndex];
     setCamera(nextCamera);
+    setCamIndex(nextIndex);
     trackEvent("click", "camera-list", "camera", nextCamera.name);
   };
 


### PR DESCRIPTION
Bug was caused by relying on the panel's camera, which (after an updated image) did not have the camGroup property, which is added on initially loading the list of cameras. The camera feature that's initially created keeps the property, so that's used now instead.

Also fixed another bug where using the directional cycle button failed to update camIndex, so after using directional cycle, clicking on the cardinal button for the original view would fail to change the view.