### PR TITLE
DBC22-5228 clicking my location always pans to user's location

### DIFF
--- a/src/frontend/src/Components/map/helpers/map.js
+++ b/src/frontend/src/Components/map/helpers/map.js
@@ -83,7 +83,7 @@ export const zoomOut = (mapView) => {
 export const toggleMyLocation = (mapRef, mapView, setMyLocationLoading, setMyLocation, setShowLocationAccessError) => {
   if ('geolocation' in navigator) {
     navigator.geolocation.getCurrentPosition(
-      position => {
+      (position) => {
         const { latitude, longitude } = position.coords;
         if (
           position.coords.longitude <= -113.7 &&
@@ -112,6 +112,7 @@ export const toggleMyLocation = (mapRef, mapView, setMyLocationLoading, setMyLoc
           };
 
           setMyLocation(myLocation);
+          setZoomPan(mapView, 9, fromLonLat([longitude, latitude]));
           setMyLocationLoading(false);
 
         } else {
@@ -132,6 +133,9 @@ export const toggleMyLocation = (mapRef, mapView, setMyLocationLoading, setMyLoc
           setMyLocationLoading(false);
         }
       },
+      {
+        maximumAge: 30000, // 30 seconds
+      }
     );
   }
 }


### PR DESCRIPTION
Code to pan/zoom to the user's location moved to click handler for my location button.  Existing functionality left undisturbed (e.g., setting the start location to "current location" if no start location is specified).  This fix is purely a map display fix.

Per discussion with Chris, when a start location exists, that location is not swapped for "current location", and the user's location is not indicated with the blue ring, which is used for the start location.