### PR TITLE
DBC22-5317: Fix for 0 updates and missing route subject

### DIFF
--- a/src/backend/apps/event/tasks.py
+++ b/src/backend/apps/event/tasks.py
@@ -447,8 +447,9 @@ def send_queued_notifications():
             html = render_to_string('email/event_updated.html', context)
 
             update_text = 'updates' if len(ordered_events) > 1 else 'update'
+            route_label = saved_route.label if saved_route.label else f'{saved_route.start} to {saved_route.end}'
             msg = EmailMultiAlternatives(
-                f'DriveBC: {len(ordered_events)} {update_text} on {saved_route.label}',
+                f'DriveBC: {len(ordered_events)} {update_text} on {route_label}',
                 text,
                 settings.DRIVEBC_FROM_EMAIL_DEFAULT,
                 [saved_route.user.email]

--- a/src/backend/apps/event/templates/email/event_updated.txt
+++ b/src/backend/apps/event/templates/email/event_updated.txt
@@ -1,4 +1,4 @@
-Update for DriveBC route {{ route.label }}
+Update for DriveBC route {% if route.label %}{{ route.label }}{% else %}{{ route.start }} to {{ route.end }}{% endif %}
 
 {% for event in events %}
 {{ event.event_type }}


### PR DESCRIPTION
This fixes 2 issues

1. Issue where it could send an email with 0 updates if the event was updated and then deleted within the 5 minute period
2. An issue where, if the user deleted the default `Label` the subject would just say `DriveBC: 1 update on [BLANK]`. Now it uses the Start and End fields to generate the route name for the subject.