### PR TITLE
DBC22-5301: Improve Events API performance and reduce DB calls

### DIFF
--- a/src/backend/apps/event/serializers.py
+++ b/src/backend/apps/event/serializers.py
@@ -49,11 +49,11 @@ def optimize_description(text):
 
 
 class EventInternalSerializer(serializers.ModelSerializer):
-    display_category = serializers.SerializerMethodField()
     direction_display = serializers.SerializerMethodField()
     route_display = serializers.SerializerMethodField()
     optimized_description = serializers.SerializerMethodField()
     schedule = ScheduleSerializer()
+    area = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 
     class Meta:
         model = Event
@@ -86,9 +86,6 @@ class EventInternalSerializer(serializers.ModelSerializer):
 
     def get_optimized_description(self, obj):
         return optimize_description(obj.description)
-
-    def get_display_category(self, obj):
-        return obj.display_category
 
 
 class EventSerializer(EventInternalSerializer):

--- a/src/backend/apps/event/views.py
+++ b/src/backend/apps/event/views.py
@@ -3,11 +3,22 @@ from apps.event.models import Event
 from apps.event.serializers import EventPollingSerializer, EventSerializer
 from apps.shared.enums import CacheKey, CacheTimeout
 from apps.shared.views import CachedListModelMixin
+from django.db.models import Prefetch
+from apps.shared.models import Area
 from rest_framework import viewsets
 
 
 class EventAPI(CachedListModelMixin):
-    queryset = Event.objects.all().exclude(status=EVENT_STATUS.INACTIVE)
+    queryset = (
+        Event.objects
+        .exclude(status=EVENT_STATUS.INACTIVE)
+        .prefetch_related(
+            Prefetch(
+                "area",
+                queryset=Area.objects.only("id"),
+            )
+        )
+    )
     serializer_class = EventSerializer
     cache_key = CacheKey.EVENT_LIST
     cache_timeout = CacheTimeout.EVENT_LIST


### PR DESCRIPTION
This fixes an N+1 issue with the Events API by prefetching the areas table. Also removed the unnecessary entry for getting display category.