### PR TITLE
DBC22-5301: Add Redis caching

### DIFF
--- a/src/backend/apps/border/tasks.py
+++ b/src/backend/apps/border/tasks.py
@@ -5,6 +5,8 @@ import zoneinfo
 import requests
 from apps.border.models import BorderCrossingLanes
 from config import settings
+from django.core.cache import cache
+from apps.shared.enums import CacheKey
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +35,5 @@ def update_border_crossing_lanes(testing=False):
         # run only once in unit tests
         if testing:
             return
+        
+    cache.delete(CacheKey.BORDER_CROSSING_LIST)

--- a/src/backend/apps/border/views.py
+++ b/src/backend/apps/border/views.py
@@ -1,8 +1,16 @@
+from apps.shared.enums import CacheKey, CacheTimeout
+from apps.shared.views import CachedListModelMixin
 from apps.border.models import BorderCrossing
 from apps.border.serializers import BorderCrossingSerializer
 from rest_framework import viewsets
 
 
-class BorderCrossingViewSet(viewsets.ReadOnlyModelViewSet):
+class BorderCrossingAPI(CachedListModelMixin):
     queryset = BorderCrossing.objects.all()
     serializer_class = BorderCrossingSerializer
+    cache_key = CacheKey.BORDER_CROSSING_LIST
+    cache_timeout = CacheTimeout.BORDER_CROSSING_LIST
+
+
+class BorderCrossingViewSet(BorderCrossingAPI, viewsets.ReadOnlyModelViewSet):
+    pass

--- a/src/backend/apps/cms/views.py
+++ b/src/backend/apps/cms/views.py
@@ -6,6 +6,8 @@ from apps.cms.serializers import (
     EmergencyAlertSerializer,
     EmergencyAlertTestSerializer,
 )
+from apps.shared.enums import CacheKey, CacheTimeout
+from apps.shared.views import CachedListModelMixin
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.http import HttpResponseRedirect
@@ -54,10 +56,13 @@ class CMSViewSet(viewsets.ReadOnlyModelViewSet):
 
         return obj
 
-class AdvisoryAPI(CMSViewSet):
-    queryset = Advisory.objects.all()
+class AdvisoryAPI(CachedListModelMixin, CMSViewSet):
+    # Filter live=True so the cache only stores public data
+    queryset = Advisory.objects.filter(live=True)
     serializer_class = AdvisorySerializer
     lookup_field = 'slug'
+    cache_key = CacheKey.ADVISORY_LIST
+    cache_timeout = CacheTimeout.ADVISORY_LIST
 
 
 class BulletinTestAPI(CMSViewSet):
@@ -66,8 +71,12 @@ class BulletinTestAPI(CMSViewSet):
     lookup_field = 'slug'
 
 
-class BulletinAPI(BulletinTestAPI):
+class BulletinAPI(CachedListModelMixin, BulletinTestAPI):
+    # Filter live=True so the cache only stores public data
+    queryset = Bulletin.objects.filter(live=True)
     serializer_class = BulletinSerializer
+    cache_key = CacheKey.BULLETIN_LIST
+    cache_timeout = CacheTimeout.BULLETIN_LIST
 
 
 class EmergencyAlertTestAPI(CMSViewSet):
@@ -76,8 +85,11 @@ class EmergencyAlertTestAPI(CMSViewSet):
     lookup_field = 'slug'
 
 
-class EmergencyAlertAPI(EmergencyAlertTestAPI):
+class EmergencyAlertAPI(CachedListModelMixin, EmergencyAlertTestAPI):
+    queryset = EmergencyAlert.objects.filter(live=True)
     serializer_class = EmergencyAlertSerializer
+    cache_key = CacheKey.EMERGENCY_ALERT_LIST
+    cache_timeout = CacheTimeout.EMERGENCY_ALERT_LIST
 
 
 @csrf_exempt

--- a/src/backend/apps/event/views.py
+++ b/src/backend/apps/event/views.py
@@ -6,6 +6,8 @@ from apps.shared.views import CachedListModelMixin
 from django.db.models import Prefetch
 from apps.shared.models import Area
 from rest_framework import viewsets
+from rest_framework.response import Response
+from django.core.cache import cache
 
 
 class EventAPI(CachedListModelMixin):
@@ -27,14 +29,57 @@ class EventAPI(CachedListModelMixin):
 class EventPollingAPI(EventAPI):
     serializer_class = EventPollingSerializer
     cache_key = CacheKey.EVENT_LIST_POLLING
+    cache_timeout = CacheTimeout.EVENT_LIST_POLLING
 
 
 class EventViewSet(EventAPI, viewsets.ReadOnlyModelViewSet):
-    pass
+    
+    def retrieve(self, request, *args, **kwargs):
+        """
+        Retrieve a single event with caching.
+        """
+        pk = kwargs.get('pk')
+        cache_key = f"event_detail_{pk}"
+        
+        # Try to get from cache
+        cached_data = cache.get(cache_key)
+        if cached_data is not None:
+            return Response(cached_data)
+        
+        # If not in cache, get from database
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        data = serializer.data
+        
+        # Cache the result
+        cache.set(cache_key, data, CacheTimeout.EVENT_INDIVUDAL)
+        
+        return Response(data)
 
 
 class EventPollingViewSet(EventPollingAPI, viewsets.ReadOnlyModelViewSet):
-    pass
+    
+    def retrieve(self, request, *args, **kwargs):
+        """
+        Retrieve a single event (polling) with caching.
+        """
+        pk = kwargs.get('pk')
+        cache_key = f"event_polling_detail_{pk}"
+        
+        # Try to get from cache
+        cached_data = cache.get(cache_key)
+        if cached_data is not None:
+            return Response(cached_data)
+        
+        # If not in cache, get from database
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        data = serializer.data
+        
+        # Cache the result
+        cache.set(cache_key, data, CacheTimeout.EVENT_INDIVUDAL)
+        
+        return Response(data)
 
 
 class EventTestViewSet(viewsets.ReadOnlyModelViewSet):

--- a/src/backend/apps/ferry/tasks.py
+++ b/src/backend/apps/ferry/tasks.py
@@ -101,6 +101,7 @@ def populate_coastal_ferry_data(test_data=None):
     if 'stop_times.txt' in csv_data:
         populate_coastal_ferry_stop_times(csv_data['stop_times.txt'])
 
+    cache.delete(CacheKey.COASTAL_FERRY_LIST)
 
 def populate_coastal_ferry_stops(stops_data):
     for stop in stops_data:

--- a/src/backend/apps/ferry/urls.py
+++ b/src/backend/apps/ferry/urls.py
@@ -9,6 +9,6 @@ coastal_router = routers.DefaultRouter()
 coastal_router.register(r"", ferry_views.CoastalViewSet, basename="coastal-ferries")
 
 urlpatterns = [
+    path("coastal/", include(coastal_router.urls)),
     path("", include(ferry_router.urls)),
-    path("coastal", include(coastal_router.urls)),
 ]

--- a/src/backend/apps/ferry/views.py
+++ b/src/backend/apps/ferry/views.py
@@ -1,5 +1,6 @@
 from apps.ferry.models import CoastalFerryStop, Ferry
 from apps.ferry.serializers import CoastalFerryStopAPISerializer, FerryRouteSerializer
+from apps.shared.enums import CacheKey, CacheTimeout
 from apps.shared.views import CachedListModelMixin
 from rest_framework import viewsets
 
@@ -7,12 +8,17 @@ from rest_framework import viewsets
 class FerryAPI(CachedListModelMixin):
     queryset = Ferry.objects.distinct('route_id')
     serializer_class = FerryRouteSerializer
-
-
-class CoastalViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = CoastalFerryStop.objects.filter(parent_stop=None)
-    serializer_class = CoastalFerryStopAPISerializer
-
+    cache_key = CacheKey.FERRY_LIST
+    cache_timeout = CacheTimeout.FERRY_LIST
 
 class FerryViewSet(FerryAPI, viewsets.ReadOnlyModelViewSet):
+    pass
+
+class CoastalFerryAPI(CachedListModelMixin):
+    queryset = CoastalFerryStop.objects.filter(parent_stop=None)
+    serializer_class = CoastalFerryStopAPISerializer
+    cache_key = CacheKey.COASTAL_FERRY_LIST
+    cache_timeout = CacheTimeout.COASTAL_FERRY_LIST
+
+class CoastalViewSet(CoastalFerryAPI, viewsets.ReadOnlyModelViewSet):
     pass

--- a/src/backend/apps/shared/enums.py
+++ b/src/backend/apps/shared/enums.py
@@ -43,11 +43,38 @@ ORIENTATION_CHOICES = (
 # Caching
 class CacheTimeout:
     DEFAULT = 120
-    WEBCAM_LIST = 60*7  # 5min buffer + (2*1)min twice of task interval
-    EVENT_LIST = 60 * 15  # 5min buffer + (2*5)min twice of task interval
-    FERRY_LIST = 60*60*24  # 24hr
-    REGIONAL_WEATHER_LIST = 60 * 15  # 5min buffer + (2*5)min twice of task interval
-    REST_STOP_LIST = 60 * 15  # 5min buffer + (2*5)min twice of task interval
+    # Manually entered so we have short 30 second TTL to ensure that we aren't serving stale data too long.
+    ADVISORY_LIST = 30 # Cache not automatically invalidated, so keep TTL short
+    BULLETIN_LIST = 30 # Cache not automatically invalidated, so keep TTL short
+    EMERGENCY_ALERT_LIST = 30 # Cache not automatically invalidated, so keep TTL short
+
+    # Huey job based timeouts. Cache timeouts are set to double the task interval to allow for delays.
+    # 1 MINUTE TASKS (Interval x 2)
+    WEBCAM_LIST = 30 # Cache is automatically invalidated after job runs. However image consumer constantly ingests images so keeping TTL short.
+    WEBCAM_INDIVIDUAL = 30 # Individual webcams are not automatically invalidated, so keep TTL short.
+    WEBCAM_REPLAYTHEDAY = 60 * 1 # Replay the day timestamps are not automatically invalidated, so keep TTL shorter.
+    EVENT_LIST = 60 * 2 # Cache is automatically invalidated after job runs
+    EVENT_LIST_POLLING = 60 * 2 # Cache is automatically invalidated after job runs
+    EVENT_INDIVUDAL = 60 * 1 # Individual events are not automatically invalidated, so keep TTL short
+    BORDER_CROSSING_LIST = 60 * 2 # Cache is automatically invalidated after job runs
+
+    # 10 MINUTE TASKS (Interval x 2)
+    REGIONAL_WEATHER_LIST = 60 * 20 # Cache is automatically invalidated after job runs
+    CURRENT_WEATHER_LIST = 60 * 20 # Cache is automatically invalidated after job runs
+    HIGH_ELEVATION_LIST = 60 * 20 # Cache is automatically invalidated after job runs
+
+    # 15 MINUTE TASKS (Interval x 2)
+    WILDFIRE_LIST = 60 * 30 # Cache is automatically invalidated after job runs
+
+    # 1 HOUR TASKS (Interval x 2)
+    FERRY_LIST = 60 * 60 * 2 # Cache is automatically invalidated after job runs
+
+    # 24 HOUR TASKS (Interval x 2)
+    REST_STOP_LIST = 60 * 60 * 48 # Cache is automatically invalidated after job runs
+
+    # WEEKLY TASKS (Interval x 2)
+    DISTRICT_LIST = 60 * 60 * 24 * 14 # Cache is automatically invalidated after job runs
+    COASTAL_FERRY_LIST = 60 * 60 * 24 * 14 # Cache is automatically invalidated after job runs
 
 
 class CacheKey:
@@ -57,11 +84,18 @@ class CacheKey:
     EVENT_LIST_POLLING = "event_list_polling"
     ADVISORY_LIST = "advisory_list"
     BULLETIN_LIST = "bulletin_list"
+    EMERGENCY_ALERT_LIST = "emergency_alert_list"
     FERRY_LIST = "ferry_list"
+    COASTAL_FERRY_LIST = "coastal_ferry_list"
     TEST_APP_CACHE = "test_app_cache"
-    REGIONAL_WEATHER_LIST = "regional_weather_list"
-    HIGH_ELEVATION_FORECAST_LIST = "high_elevation_forecast_list"
+    REGIONAL_WEATHER_LIST = 'regional_weather_list'
+    CURRENT_WEATHER_LIST = 'current_weather_list'
+    HIGH_ELEVATION_LIST = 'high_elevation_list'
     REST_STOP_LIST = "rest_stop_list"
+    WILDFIRE_LIST = "wildfire_list"
+    BORDER_CROSSING_LIST = 'border_crossing_list'
+    DISTRICT_LIST = 'district_list'
+    
 
 
 ROUTE_FILTER_TOLERANCE = 25

--- a/src/backend/apps/shared/tasks.py
+++ b/src/backend/apps/shared/tasks.py
@@ -10,6 +10,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from email_log.models import Email
 from huey import crontab
 from huey.contrib.djhuey import db_periodic_task, lock_task
+from django.core.cache import cache
+from apps.shared.enums import CacheKey
 
 
 @db_periodic_task(crontab(hour="*/24", minute="0"))
@@ -41,6 +43,8 @@ def populate_all_district_data():
 
     for district_data in feed_data:
         populate_district_from_data(district_data)
+
+    cache.delete(CacheKey.DISTRICT_LIST)    
 
 
 def update_object_relations():

--- a/src/backend/apps/weather/tasks.py
+++ b/src/backend/apps/weather/tasks.py
@@ -84,7 +84,7 @@ def populate_all_high_elevation_forecast_data():
         HighElevationForecast.objects.exclude(code__in=codes).delete()
 
     # Rebuild cache
-    cache.delete(CacheKey.HIGH_ELEVATION_FORECAST_LIST)
+    cache.delete(CacheKey.HIGH_ELEVATION_LIST)
 
 
 def populate_local_weather_from_data(new_current_weather_data):
@@ -113,3 +113,6 @@ def populate_all_local_weather_data(token=None):
     # feed so that an erroneous empty response doesn't empty our list
     if len(codes) > 0:
         CurrentWeather.objects.exclude(code__in=codes).delete()
+
+    # Rebuild cache
+    cache.delete(CacheKey.CURRENT_WEATHER_LIST)    

--- a/src/backend/apps/weather/urls.py
+++ b/src/backend/apps/weather/urls.py
@@ -3,11 +3,11 @@ from django.urls import include, path
 from rest_framework import routers
 
 weather_router = routers.DefaultRouter()
-weather_router.register(r"", weather_views.WeatherViewSet, basename="weather")
+
+weather_router.register(r"regional", weather_views.RegionalWeatherViewSet, basename="regional")
+weather_router.register(r"current", weather_views.CurrentWeatherViewSet, basename="current")
+weather_router.register(r"hef", weather_views.HighElevationViewSet, basename="hef")
 
 urlpatterns = [
-    path('regional', weather_views.WeatherViewSet.as_view({'get': 'regional'}), name='regional'),
-    path('current', weather_views.WeatherViewSet.as_view({'get': 'current'}), name='current'),
-    path('hef', weather_views.WeatherViewSet.as_view({'get': 'hef'}), name='hef'),
     path('', include(weather_router.urls)),
 ]

--- a/src/backend/apps/weather/views.py
+++ b/src/backend/apps/weather/views.py
@@ -6,33 +6,32 @@ from apps.weather.serializers import (
     HighElevationForecastSerializer,
     RegionalWeatherSerializer,
 )
-from rest_framework import status, viewsets
-from rest_framework.decorators import action
-from rest_framework.response import Response
+from rest_framework import viewsets
 
 
 class RegionalWeatherAPI(CachedListModelMixin):
-    queryset = RegionalWeather.objects.all()
+    queryset = RegionalWeather.objects.all().exclude(code=None)
     serializer_class = RegionalWeatherSerializer
     cache_key = CacheKey.REGIONAL_WEATHER_LIST
     cache_timeout = CacheTimeout.REGIONAL_WEATHER_LIST
 
+class RegionalWeatherViewSet(RegionalWeatherAPI, viewsets.ReadOnlyModelViewSet):
+    pass
 
-class WeatherViewSet(viewsets.ViewSet):
-    @action(detail=True, methods=['get'])
-    def regional(self, request, pk=None):
-        regional_weather_objects = RegionalWeather.objects.all().exclude(code=None)
-        serializer = RegionalWeatherSerializer(regional_weather_objects, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+class CurrentWeatherAPI(CachedListModelMixin):
+    queryset = CurrentWeather.objects.all().exclude(code=None)
+    serializer_class = CurrentWeatherSerializer
+    cache_key = CacheKey.CURRENT_WEATHER_LIST
+    cache_timeout = CacheTimeout.CURRENT_WEATHER_LIST
 
-    @action(detail=True, methods=['get'])
-    def current(self, request, pk=None):
-        current_weather_objects = CurrentWeather.objects.all().exclude(code=None)
-        serializer = CurrentWeatherSerializer(current_weather_objects, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+class CurrentWeatherViewSet(CurrentWeatherAPI, viewsets.ReadOnlyModelViewSet):
+    pass
 
-    @action(detail=True, methods=['get'])
-    def hef(self, request, pk=None):
-        forecasts = HighElevationForecast.objects.all()
-        serializer = HighElevationForecastSerializer(forecasts, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+class HighElevationAPI(CachedListModelMixin):
+    queryset = HighElevationForecast.objects.all()
+    serializer_class = HighElevationForecastSerializer
+    cache_key = CacheKey.HIGH_ELEVATION_LIST
+    cache_timeout = CacheTimeout.HIGH_ELEVATION_LIST
+
+class HighElevationViewSet(HighElevationAPI, viewsets.ReadOnlyModelViewSet):
+    pass

--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -37,6 +37,8 @@ import boto3
 from django.utils import timezone
 from django.forms.models import model_to_dict
 from django.db.models import F, Case, When, Value, IntegerField
+from apps.shared.enums import CacheKey
+from django.core.cache import cache
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -330,7 +332,7 @@ def update_all_webcam_data():
         current_time = datetime.datetime.now(tz=ZoneInfo("America/Vancouver"))
         if camera.https_cam:
             update_cam_from_sql_db(camera.id, current_time)
-
+    cache.delete(CacheKey.WEBCAM_LIST)
 
 def wrap_text(text, pen, font, width):
     '''

--- a/src/backend/apps/wildfire/tasks.py
+++ b/src/backend/apps/wildfire/tasks.py
@@ -4,6 +4,8 @@ from apps.feed.client import FeedClient
 from apps.wildfire.models import Wildfire
 from apps.wildfire.serializers import WildfireInternalSerializer
 from django.core.exceptions import ObjectDoesNotExist
+from apps.shared.enums import CacheKey
+from django.core.cache import cache
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +68,6 @@ def populate_all_wildfire_data():
     logger.warning("active wildfire count: %s", len(active_wildfires))
     if len(active_wildfires) > 0:  # 2025/09/09 hotfix to prevent deletion of all wildfires
         Wildfire.objects.exclude(id__in=active_wildfires).delete()
+
+    # Rebuild cache
+    cache.delete(CacheKey.WILDFIRE_LIST)

--- a/src/backend/apps/wildfire/views.py
+++ b/src/backend/apps/wildfire/views.py
@@ -1,8 +1,15 @@
 from apps.wildfire.models import Wildfire
 from apps.wildfire.serializers import WildfireSerializer
+from apps.shared.enums import CacheKey, CacheTimeout
+from apps.shared.views import CachedListModelMixin
 from rest_framework import viewsets
 
 
-class WildfireViewSet(viewsets.ReadOnlyModelViewSet):
+class WildfireAPI(CachedListModelMixin):
     queryset = Wildfire.objects.filter(status='Out of Control')
     serializer_class = WildfireSerializer
+    cache_key = CacheKey.WILDFIRE_LIST
+    cache_timeout = CacheTimeout.WILDFIRE_LIST
+
+class WildfireViewSet(WildfireAPI, viewsets.ReadOnlyModelViewSet):
+    pass


### PR DESCRIPTION
There were a few API's that had redis caching enabled, but a lot did not. 
To improve backend performance and reduce load on the DB I added caching to the public API's so that we have significantly less hits on the DB. The ticket has a performance comparison, but most are 90%+ faster when it comes from the cache vs from the DB.
Most caches are cleared when the job runs, but for ones that aren't (ie for CMS API's) they have a short TTL to ensure they don't get too stale.
Take a look at the enums file and see if the values are reasonable.