### PR TITLE
DBC22-4346: avoided camera credit html tag stripped out

### DIFF
--- a/src/backend/apps/webcam/serializers.py
+++ b/src/backend/apps/webcam/serializers.py
@@ -13,6 +13,7 @@ class WebcamSerializer(serializers.ModelSerializer):
     highway_display = serializers.SerializerMethodField()
     marked_stale = serializers.SerializerMethodField()
     marked_delayed = serializers.SerializerMethodField()
+    credit = serializers.SerializerMethodField()
 
     class Meta:
         model = Webcam
@@ -20,6 +21,9 @@ class WebcamSerializer(serializers.ModelSerializer):
             "created_at",
             "modified_at",
         )
+
+    def get_credit(self, obj):
+        return obj.credit
 
     def get_name(self, obj):
         return obj.name_override if obj.name_override else obj.name


### PR DESCRIPTION
For WebcamSerializer, applied SerializerMethodField for credit field to avoid html tag got stripped out.
This issue only happens when a route was saved, then SafeStringMixin triggers SafeStringField get html tag stripped.