### PR TITLE
DBC22-5388: Add code back to weather API's

### DIFF
--- a/src/backend/apps/weather/serializers.py
+++ b/src/backend/apps/weather/serializers.py
@@ -13,6 +13,7 @@ class RegionalWeatherSerializer(serializers.ModelSerializer):
         model = RegionalWeather
         fields = [
             'id',
+            'code',
             'location',
             'conditions',
             'name',
@@ -44,6 +45,7 @@ class CurrentWeatherSerializer(serializers.ModelSerializer):
         model = CurrentWeather
         fields = [
             'id',
+            'code',
             'weather_station_name',
             'air_temperature',
             'average_wind',


### PR DESCRIPTION
id used to be the code, but when we did the fix for the API, id became id and we no longer included code.
To aid in troubleshooting, having code helps quite a bit.