### PR TITLE
DBC22-4273: Update BC Sans Package version

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@bcgov/bc-sans": "^1.0.1",
+        "@bcgov/bc-sans": "^2.1.0",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-brands-svg-icons": "^6.4.2",
         "@fortawesome/pro-light-svg-icons": "^6.5.2",
@@ -2084,9 +2084,10 @@
       }
     },
     "node_modules/@bcgov/bc-sans": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-1.0.1.tgz",
-      "integrity": "sha512-4suRUBFeHcuFkwXXJu9pKJNB5Z2G3bpuLEHIq203KVCKC8KrsnqvsyUOf645TypgLwqOTOYCETiXYzfxF4gLAw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-2.1.0.tgz",
+      "integrity": "sha512-1MesF4NAVpM5dywoJ68wNcBylHbPqg1dDV/FNuQm0BbspETGlPmfX8LG8rtrCjCAPhWuL2qRT/lBYDUMvFTUnw==",
+      "license": "SIL"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@bcgov/bc-sans": "^1.0.1",
+    "@bcgov/bc-sans": "^2.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/pro-light-svg-icons": "^6.5.2",
@@ -20,6 +20,7 @@
     "@uidotdev/usehooks": "^2.0.1",
     "@vaadin/date-picker": "^24.6.2",
     "@vaadin/time-picker": "^24.6.2",
+    "@vladyoslav/drawer": "^0.1.0",
     "bootstrap": "^5.3.0",
     "env-cmd": "^10.1.0",
     "flatbush": "^4.4.0",
@@ -54,8 +55,7 @@
     "redux-persist": "^6.0.0",
     "title-case": "^4.3.2",
     "ua-parser-js": "^2.0.3",
-    "web-vitals": "^2.1.4",
-    "@vladyoslav/drawer": "^0.1.0"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "env-cmd -f ../../.env react-scripts start",


### PR DESCRIPTION
This simply updates the bc sans package from 1.0.1 to 2.1.0 because the newer package has woff2 thus saving about 40% in bandwidth on just these two files.