### PR TITLE
DBC22-5415: used environment variable to populate self links for stale and delayed endpoint

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -186,6 +186,7 @@ server {
         proxy_cache_valid 200 30s;
         proxy_cache_valid 404 1s;
         proxy_cache_bypass $http_cachebypass;
+        proxy_set_header Host $host;
         include /etc/nginx/conf.d/security_headers.conf;
     }
 


### PR DESCRIPTION
DBC22-5415: used environment variable to populate self links for stale and delayed endpoint