### PR TITLE
DBC22-5425: Fix ALLOWED_HOSTS issue for sysdig

### DIFF
--- a/infrastructure/main/charts/django/templates/django-deployment.yaml
+++ b/infrastructure/main/charts/django/templates/django-deployment.yaml
@@ -71,6 +71,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:

--- a/src/backend/config/settings/django.py
+++ b/src/backend/config/settings/django.py
@@ -36,6 +36,11 @@ SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT")
 SESSION_COOKIE_SECURE = env.bool("DJANGO_SESSION_COOKIE_SECURE")
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# Allow the pod IP to be an allowed host so that Sysdig prometheus scraping works
+pod_ip = os.getenv('POD_IP')
+if pod_ip:
+    ALLOWED_HOSTS.append(pod_ip)
+
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     "django.middleware.gzip.GZipMiddleware",


### PR DESCRIPTION
Sysdig simply scrapes using the IP:PORT as the HOST which caused it to fail the ALLOWED_HOSTS check.
This adds a new env variable for the pod IP to the pod and then appends that IP to the ALLOWED_HOSTS in django. In dev this works as expected.