### PR TITLE
DBC22-5201: used clickedFeature to update icon status

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -858,7 +858,7 @@ export default function DriveBCMap(props) {
     if (filteredEvents) {
       // Toggle features visibility
       updateEventsLayers(
-        mapContext, filteredEvents, mapLayers, setLoadingLayers, referenceData, mapView,
+        mapContext, filteredEvents, mapLayers, setLoadingLayers, clickedFeature, mapView,
         featureContext, setFeatureContext // DBC22-5106
       );
 

--- a/src/frontend/src/Components/map/layers/eventsLayer.js
+++ b/src/frontend/src/Components/map/layers/eventsLayer.js
@@ -194,7 +194,7 @@ export function loadEventsLayers(eventsData, mapContext, mapLayers, mapRef, refe
 }
 
 export function updateEventsLayers(
-  mapContext, events, mapLayers, setLoadingLayers, referenceData, mapView,
+  mapContext, events, mapLayers, setLoadingLayers, clickedFeature, mapView,
   featureContext, setFeatureContext  // Feature context for route details panel
 ) {
   const featuresDict = {};
@@ -217,7 +217,7 @@ export function updateEventsLayers(
       if (featureId in eventsDict) {
         // Update the feature with the new event data
         feature.setProperties(eventsDict[featureId]);
-        setEventStyle(feature, referenceData.id === featureId ? 'active' : 'static');
+        setEventStyle(feature, clickedFeature?.getId() === featureId ? 'active' : 'static');
         processedEvents.add(featureId);  // Track processed events
         featuresDict[featureId] = feature;
 


### PR DESCRIPTION
https://moti-imb.atlassian.net/browse/DBC22-5201

Test steps:
1. Create a route that includes events along the way (e.g., from Hope to Coquitlam).
2. Click on one of the event icons and confirm that it becomes highlighted.
3. Verify that the highlighted icon remains selected. Expected result: the icon stays highlighted and does not lose its state during periodic page refreshes (every few seconds).