### PR TITLE
DBC22-5577: Added a fallback for nearby weather information when Local weather is empty

### DIFF
--- a/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.js
+++ b/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.js
@@ -48,7 +48,19 @@ export default function NearbyWeathers(props) {
   // States
   const [activeTab, setActiveTab] = useState('Local');
 
+  const btnTitles = ['Local', 'Regional', 'High elevation'];
+
   // Effects
+
+  // if Local has no data once its list has loaded, switch to the first tab that does.
+  useEffect(() => {
+    if (activeTab !== 'Local') return;
+    if (currentWeatherList == null || localWeather) return;
+
+    if (regionalWeather) setActiveTab('Regional');
+    else if (hef) setActiveTab('High elevation');
+  }, [currentWeatherList, localWeather, regionalWeather, hef, activeTab]);
+
   // find regional weather and set state
   useEffect(() => {
     if (!regionalWeatherList || !camera.regional_weather_station) {
@@ -92,9 +104,6 @@ export default function NearbyWeathers(props) {
       </div>
     );
   }
-
-  // Main component
-  const btnTitles = ['Local', 'Regional', 'High elevation'];
 
   return (
     <React.Fragment>


### PR DESCRIPTION
### 📝 Min Ji Choi

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5577

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally — NA
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [x] **New Env Variables:** Does this PR require new environment variables? — No
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Need to pass in an empty entry in the local weather data
2. Find a camera in Cameras page that would usually shows that local weather station.
3. Verify that the "Local" tab is not present, and the next available tab is active ("Regional").

---

### 🔍 Reviewer Checklist
- [x] Reviewed code for logic and cleanliness
- [x] Re-tested desktop/mobile in local or dev envs
- [x] Verified no new console warnings/errors
- [x] Confirmed that any new env variables are understood/documented