### PR TITLE
DBC22-5879: made message_display/1/2/3 read only

### DIFF
--- a/src/backend/apps/dms/admin.py
+++ b/src/backend/apps/dms/admin.py
@@ -3,6 +3,6 @@ from django.contrib.gis import admin
 
 
 class DmsAdmin(admin.GISModelAdmin):
-    readonly_fields = ('id', )
+    readonly_fields = ('id', 'message_display_1', 'message_display_2', 'message_display_3')
 
 admin.site.register(Dms, DmsAdmin)


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5879

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Login to django admin backend
2. Click any DMS (dmc for Zopkois Chain Up).
3. Verify if message_display_1/2/3 are read-only or not.
4. Input a test message in message text something like: [pt30o0][fo1]PLAN YOUR ROUTE[nl][fo1]BEFORE YOU GO[np][pt30o0][fo1]CHECK[nl][fo1]http://DRIVEBC.CA, and save.
5. Reopen the item just updated to verify if message_display_1/2/3 are read-only or not

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented