### PR TITLE
DBC22-6034: Respect precedence field from SAWSx

### DIFF
--- a/src/backend/apps/feed/client.py
+++ b/src/backend/apps/feed/client.py
@@ -501,6 +501,12 @@ class FeedClient:
             if not has_weather_data:
                 continue
 
+            def precedence_sort(ds):
+                p = ds.get("Precedence")
+                return p if p is not None else 1
+
+            mapped_datasets.sort(key=precedence_sort, reverse=True)
+
             filtered_dataset = {}
             for dataset in mapped_datasets:
                 dataset_name = dataset.get("DataSetName")


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6034

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.


#### 🧪 How to Test (if required)
1. Call the API locally for a weather station that has multiple of same sensor types (ie Pothole 29093 in dev)
2. Find the `"DataSetName": "air_temp",` field and check the precedence of the entries
3. Wait for the tasks pod to run the current weather job to update the weather data
4. Login to drivebc-admin and find the pothole weather station
5. Check the datasets field and look for air_temperature
6. Confirm that we are using the field with higher precedence.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented