### PR TITLE
DBC22-6162: reset map center based on root camera location

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -617,6 +617,17 @@ export default function DriveBCMap(props) {
       );
     });
 
+    if (rootCamera) {
+      mapRef.current.on('change:size', function() {
+        mapView.current.setCenter(
+          fromLonLat([
+            rootCamera.location.coordinates[0],
+            rootCamera.location.coordinates[1]
+          ])
+        );
+      });
+    }
+
     // Event listeners
     mapRef.current.on('click', async e => {
       const features = mapRef.current.getFeaturesAtPixel(e.pixel, {

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -620,6 +620,9 @@ export default function DriveBCMap(props) {
 
     if (rootCamera) {
       mapRef.current.on('change:size', function() {
+        const params = new URLSearchParams(window.location.search);
+        const urlZoom = parseFloat(params.get('zoom'));
+        mapView.current.setZoom(urlZoom);
         mapView.current.setCenter(
           fromLonLat([
             rootCamera.location.coordinates[0],

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -36,6 +36,7 @@ import { useMediaQuery } from '@uidotdev/usehooks';
 import Button from 'react-bootstrap/Button';
 import cloneDeep from 'lodash/cloneDeep';
 import Spinner from 'react-bootstrap/Spinner';
+import PropTypes from 'prop-types';
 
 // Internal imports
 import { addCameraGroups } from '../data/webcams.js';
@@ -1341,3 +1342,13 @@ export default function DriveBCMap(props) {
     </div>
   );
 }
+
+DriveBCMap.propTypes = {
+  mapProps: PropTypes.shape({
+    rootCamera: PropTypes.shape({
+      location: PropTypes.shape({
+        coordinates: PropTypes.arrayOf(PropTypes.number),
+      }),
+    }),
+  }),
+};


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6162

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Go to camera details page, resize browser window small until nearby tab shows up
2. Verify if the mini map can be shown correctly instead of showing a wrong map center

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented