### PR TITLE
DBC22-5878: added auto full line-height gap between content paragraphs

### DIFF
--- a/src/frontend/src/App.scss
+++ b/src/frontend/src/App.scss
@@ -132,11 +132,11 @@ a[href^="https://" i]#{$external-link-optouts}:not([href*="drivebc.ca" i]) {
     padding-top: 0;
 
     p, ol, ul {
-      margin-bottom: 0.25rem;
+      margin-bottom: 1em;
     }
 
     p:empty {
-      height: 24px;
+      height: 0;
       margin-bottom: 0;
     }
 


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5878

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Login to wagtail backend, create/edit advisories/bulletins with multiple paragraphs in the rich-text content without adding any carriage returns, and publish the advisory or bulletin.
2. Go to dbc frontend to verify if there are auto vertical spaces added between paragraphs.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented