### PR TITLE
DBC22-5926: Re-positioning modal to fix cut-off from header

### DIFF
--- a/src/frontend/src/Components/routing/RouteDetails.scss
+++ b/src/frontend/src/Components/routing/RouteDetails.scss
@@ -320,6 +320,11 @@
   }
 
   .modal-dialog {
+
+    @media (max-width: 575px) {
+      margin-top: 180px;
+    }
+
     .route-nickname {
       display: flex;
       align-items: center;


### PR DESCRIPTION
### 📝 Submitter: Min Ji Choi

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5926

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** N/A
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [x] **New Env Variables:** Does this PR require new environment variables? No
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Sign in to your account on the site on mobile
2. Search for a route
3. Click on the button that saves the route to trigger open the modal
4. Click on the tooltip to expand it
5. Verify that the modal is below the header as well as the tooltip when expanded

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented