### PR TITLE
DBC22-5334: Fix for tooltips on event next update

### DIFF
--- a/src/frontend/src/Components/map/panels/EventPanel.scss
+++ b/src/frontend/src/Components/map/panels/EventPanel.scss
@@ -43,7 +43,7 @@
           margin-bottom: 0;
         }
 
-        &.last-update {
+        &.last-update, &.next-update {
           .friendly-time-text {
             font-size: 0.875rem;
           }


### PR DESCRIPTION
### 📝 Submitter: Min Ji Choi

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5334

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** N/A
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [x] **New Env Variables:** Does this PR require new environment variables? No
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Click on an event on the desktop browser
2. Verify that it has both Last update and Next update in a truncated form (as a link that opens up a tooltip)
3. Click on them and verify that they both don't get cut off by the edge of the browser

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented