### PR TITLE
DBC22-6209: strip the time portion of the datetime string before parsing

### DIFF
--- a/src/backend/apps/event/helpers.py
+++ b/src/backend/apps/event/helpers.py
@@ -6,7 +6,8 @@ from apps.event.enums import EVENT_DISPLAY_CATEGORY, EVENT_SEVERITY
 
 def parse_recurring_datetime(date_string, time_string):
     # Parse the date and time strings into datetime objects
-    date = datetime.datetime.strptime(date_string, "%Y-%m-%d").date()
+    stripped_date_string = date_string.split("T")[0]
+    date = datetime.datetime.strptime(stripped_date_string, "%Y-%m-%d").date()
     time = datetime.datetime.strptime(time_string, "%H:%M").time()
 
     # Combine the date and time into a single datetime object


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6209

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Verify if tasks pod log still report warnings like "[2026-04-14 09:37:26,886] WARNING:apps.event.tasks:Worker-1:unconverted data remains: T15:43:45-07:00
"

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented