### PR TITLE
DBC22-6080: Add Brotli/zstd compression to backend

### DIFF
--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -49,6 +49,7 @@ map $http_accept $client_format {
 map $http_accept_encoding $normalized_encoding {
     default         "";
     "~*br"          "br";
+    "~*zstd"        "zstd";
     "~*gzip"        "gzip";
 }
 

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -48,8 +48,8 @@ map $http_accept $client_format {
 
 map $http_accept_encoding $normalized_encoding {
     default         "";
-    "~*br"          "br";
     "~*zstd"        "zstd";
+    "~*br"          "br";
     "~*gzip"        "gzip";
 }
 

--- a/compose/frontend/default.conf
+++ b/compose/frontend/default.conf
@@ -48,6 +48,7 @@ map $http_accept $client_format {
 
 map $http_accept_encoding $normalized_encoding {
     default         "";
+    "~*zstd"        "zstd";
     "~*br"          "br";
     "~*gzip"        "gzip";
 }

--- a/src/backend/config/settings/django.py
+++ b/src/backend/config/settings/django.py
@@ -43,7 +43,7 @@ if pod_ip:
 
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
-    "django.middleware.gzip.GZipMiddleware",
+    "django_http_compression.middleware.HttpCompressionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -86,6 +86,7 @@ SHOW_DEBUG_TOOLBAR = env('SHOW_DEBUG_TOOLBAR', default=False)
 DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': lambda request: SHOW_DEBUG_TOOLBAR,
 }
+
 
 # Auth
 AUTH_USER_MODEL = "authentication.DriveBCUser"
@@ -158,6 +159,7 @@ THIRD_PARTY_APPS = [
     "drf_spectacular",
     "drf_spectacular_sidecar",
     'django_prometheus',
+    'django_http_compression'
 ]
 
 LOCAL_APPS = [

--- a/src/backend/config/settings/django.py
+++ b/src/backend/config/settings/django.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import environ
 from corsheaders.defaults import default_headers
 
+import django_brotli.middleware as brotli_mw
+
 # Base dir and env
 BASE_DIR = Path(__file__).resolve().parents[4]
 SRC_DIR = Path(__file__).resolve().parents[3]
@@ -44,6 +46,7 @@ if pod_ip:
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     "django.middleware.gzip.GZipMiddleware",
+    'django_brotli.middleware.BrotliMiddleware',
     "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -86,6 +89,9 @@ SHOW_DEBUG_TOOLBAR = env('SHOW_DEBUG_TOOLBAR', default=False)
 DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': lambda request: SHOW_DEBUG_TOOLBAR,
 }
+
+# Compression
+brotli_mw.BROTLI_QUALITY = 6
 
 # Auth
 AUTH_USER_MODEL = "authentication.DriveBCUser"

--- a/src/backend/config/settings/django.py
+++ b/src/backend/config/settings/django.py
@@ -4,8 +4,6 @@ from pathlib import Path
 import environ
 from corsheaders.defaults import default_headers
 
-import django_brotli.middleware as brotli_mw
-
 # Base dir and env
 BASE_DIR = Path(__file__).resolve().parents[4]
 SRC_DIR = Path(__file__).resolve().parents[3]
@@ -45,8 +43,7 @@ if pod_ip:
 
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
-    "django.middleware.gzip.GZipMiddleware",
-    'django_brotli.middleware.BrotliMiddleware',
+    "django_http_compression.middleware.HttpCompressionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -90,8 +87,6 @@ DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': lambda request: SHOW_DEBUG_TOOLBAR,
 }
 
-# Compression
-brotli_mw.BROTLI_QUALITY = 6
 
 # Auth
 AUTH_USER_MODEL = "authentication.DriveBCUser"
@@ -164,6 +159,7 @@ THIRD_PARTY_APPS = [
     "drf_spectacular",
     "drf_spectacular_sidecar",
     'django_prometheus',
+    'django_http_compression'
 ]
 
 LOCAL_APPS = [

--- a/src/backend/requirements/base.txt
+++ b/src/backend/requirements/base.txt
@@ -33,3 +33,4 @@ django-prometheus==2.4.1
 django-redis==6.0.0
 PyJWT==2.11.0
 cryptography==46.0.5
+django-http-compression[brotli]==1.4.0

--- a/src/backend/requirements/base.txt
+++ b/src/backend/requirements/base.txt
@@ -33,4 +33,4 @@ django-prometheus==2.4.1
 django-redis==6.0.0
 PyJWT==2.11.0
 cryptography==46.0.5
-django-brotli==0.4.0
+django-http-compression[brotli]==1.4.0

--- a/src/backend/requirements/base.txt
+++ b/src/backend/requirements/base.txt
@@ -33,3 +33,4 @@ django-prometheus==2.4.1
 django-redis==6.0.0
 PyJWT==2.11.0
 cryptography==46.0.5
+django-brotli==0.4.0


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6080

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.


#### 🧪 How to Test (if required)
1. Open devtools
2. Confirm that the API's are using br for compression
3. Try run a few curl requests like these with different encoding types `curl -v -X GET -H "Accept-Encoding: gzip, br" "https://dev.drivebc.ca/api/webcams/?" -o /dev/null`
4. `curl -v -X GET -H "Accept-Encoding: gzip, br, zstd" "https://dev.drivebc.ca/api/webcams/?" -o /dev/null`
5. `curl -v -X GET -H "Accept-Encoding: gzip" "https://dev.drivebc.ca/api/webcams/?" -o /dev/null`
6. All should return the encoding you requested with zstd being first priority, br second and gzip 3rd.
7. Go to dev.drivebc.ca and confirm site and API's work as expected. Also try on mobile.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented