### PR TITLE
DBC22-6142: Fixing word break for emergency alert on mobile

### DIFF
--- a/src/frontend/src/Components/shared/EmergencyAlert.scss
+++ b/src/frontend/src/Components/shared/EmergencyAlert.scss
@@ -21,16 +21,26 @@
   .fg-content {
     display: flex;
     flex-direction: row;
+    word-break: break-word;
 
     .fg-exclamation {
       margin-right: .5rem;
       margin-top: .3rem;
     }
 
+    span p,
+    span div {
+      display: inline;
+    }
+
     p {
       margin: 0;
       color: white;
       overflow-wrap: break-word;
+    }
+
+    a:after {
+      filter: brightness(0) invert(1);
     }
   }
 
@@ -49,10 +59,5 @@
     &:after {
       filter: brightness(0) invert(1);
     }
-  }
-
-  .fg-content span p,
-  .fg-content span div {
-    display: inline;
   }
 }


### PR DESCRIPTION
### 📝 Submitter: Min Ji Choi

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6142

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** N/A
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [x] **New Env Variables:** Does this PR require new environment variables? No
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Add a dummy emergency alert with a very long message that does not have any spaces/breaks
2. Verify on mobile that the close "x" button is accessible

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented