### PR TITLE
DBC22-5164: listen to gold and golddr rabbitmq in parallel

### DIFF
--- a/src/backend/apps/consumer/processor.py
+++ b/src/backend/apps/consumer/processor.py
@@ -58,7 +58,6 @@ S3_BUCKET = os.getenv("S3_BUCKET")
 S3_REGION = os.getenv("S3_REGION")
 S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY")
 S3_SECRET_KEY = os.getenv("S3_SECRET_KEY")
-RABBITMQ_URL = os.getenv("RABBITMQ_URL")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
 QUEUE_NAME = os.getenv("RABBITMQ_QUEUE_NAME")
 QUEUE_MAX_BYTES = int(os.getenv("RABBITMQ_QUEUE_MAX_BYTES", "209715200"))
@@ -68,9 +67,6 @@ CAMERA_CACHE_REFRESH_SECONDS = int(os.getenv("CAMERA_CACHE_REFRESH_SECONDS", "60
 RABBITMQ_HEARTBEAT = int(os.getenv("RABBITMQ_HEARTBEAT", "60"))
 RABBITMQ_TIMEOUT = int(os.getenv("RABBITMQ_TIMEOUT", "30")) 
 RABBITMQ_RECONNECT_INTERVAL = int(os.getenv("RABBITMQ_RECONNECT_INTERVAL", "5"))
-
-
-#boto3.set_stream_logger('botocore', logging.DEBUG)
 
 # S3 client configuration
 config = Config(
@@ -101,9 +97,6 @@ db_data = []  # cached camera metadata from SQL
 last_camera_refresh = {}
 image_invalid = False
 
-last_activity = 0.0  # Track last message processing time
-health_check_interval = 60  # seconds
-max_idle_time = 300  # 5 minutes before warning
 
 tz_pst = 'America/Vancouver'
 
@@ -119,135 +112,153 @@ async def on_channel_close(ch, exc=None):
     logger.warning(f"RabbitMQ channel closed: {exc}")
 
 
-async def on_message(message: aio_pika.IncomingMessage):
-    """Process incoming RabbitMQ message."""
-    if stop_event.is_set():
-        logger.info("Stop requested. Dropping message.")
-        return
-    
-    async with message.process(ignore_processed=True):
-        filename = message.headers.get("filename", "unknown.jpg")
-        camera_id = filename.split("_")[0].split(".")[0]
-        timestamp_utc = message.headers.get("timestamp", "unknown")
-        camera_status = calculate_camera_status(camera_id, timestamp_utc)
-        
-        try:
-            timestamp_local = await sync_to_async(safe_db_call)(
-                generate_local_timestamp, db_data, camera_id, timestamp_utc
-            )
+async def setup_rabbitmq(rb_url: str, name: str):
+    connection = await aio_pika.connect_robust(
+        rb_url,
+        heartbeat=RABBITMQ_HEARTBEAT,
+        timeout=RABBITMQ_TIMEOUT,
+        reconnect_interval=RABBITMQ_RECONNECT_INTERVAL,
+        fail_fast=False,
+    )
+    logger.info(f"RabbitMQ connection established for {name}.")
+    connection.reconnect_callbacks.add(on_reconnect)
+    connection.close_callbacks.add(on_close)
+
+    channel = await connection.channel()
+    logger.info(f"RabbitMQ channel created for {name}.")
+    channel.close_callbacks.add(on_channel_close)
+
+    exchange = await channel.declare_exchange(
+        EXCHANGE_NAME,
+        type=aio_pika.ExchangeType.FANOUT,
+        durable=True,
+    )
+
+    queue = await channel.declare_queue(
+        QUEUE_NAME,
+        durable=True,
+        exclusive=False,
+        auto_delete=False,
+        arguments={
+            "x-max-length-bytes": QUEUE_MAX_BYTES,
+            "x-queue-type": "quorum"
+        },
+    )
+
+    await queue.bind(exchange)
+
+    return connection, queue
+
+async def consume_queue(queue, name: str):
+    async with queue.iterator() as queue_iter:
+        async for message in queue_iter:
+            if stop_event.is_set():
+                logger.info(f"Stop requested. Breaking consume loop for {name}.")
+                break
+
             try:
-                await asyncio.wait_for(
-                    handle_image_message(camera_id, message.body, timestamp_local, camera_status),
-                    timeout=120
-                )
-            except asyncio.TimeoutError:
-                logger.error(f"Processing timeout for camera {camera_id}")
-            
-            logger.info("Processed message for camera %s.", camera_id)
-        except Exception as e:
-            logger.exception("Failed processing message (camera %s): %s", camera_id, e)
-            await asyncio.sleep(2)
+                await process_message(message)
+            except Exception as e:
+                logger.error(f"Error processing message from {name}: {e}")
 
-async def wait_for_timeout_or_signal(timeout_seconds: int):
-    """Wait for timeout or stop signal."""
-    try:
-        await asyncio.wait_for(stop_event.wait(), timeout=timeout_seconds)
-        return True  # Stop signal received
-    except asyncio.TimeoutError:
-        return False  # Timeout reached
-
-async def run_consumer():
-    """Long-running RabbitMQ consumer with automatic reconnection."""
-    
+async def consume_from(rb_url: str, name: str):
     while not stop_event.is_set():
         connection = None
-        channel = None
-        queue = None
-        
+
         try:
-            # 1. Connect to RabbitMQ (auto-reconnects on RabbitMQ restart)
-            connection = await aio_pika.connect_robust(
-                RABBITMQ_URL,
-                heartbeat=RABBITMQ_HEARTBEAT,
-                timeout=RABBITMQ_TIMEOUT,
-                reconnect_interval=RABBITMQ_RECONNECT_INTERVAL,
-                fail_fast=False,
-            )
-            logger.info("RabbitMQ connection established.")
-            connection.reconnect_callbacks.add(on_reconnect)
-            connection.close_callbacks.add(on_close)
-            
-            # 2. Setup channel and queue
-            channel = await connection.channel()
-            logger.info("RabbitMQ channel created.")
-            channel.close_callbacks.add(on_channel_close)
-            
-            exchange = await channel.declare_exchange(
-                EXCHANGE_NAME,
-                type=aio_pika.ExchangeType.FANOUT,
-                durable=True,
-            )
-            logger.info(f"RabbitMQ exchange '{EXCHANGE_NAME}' declared.")
-            
-            # # Delete existing queue if wrong type, then recreate as quorum
-            # try:
-            #     await channel.queue_delete(QUEUE_NAME)
-            #     logger.info(f"Deleted existing queue '{QUEUE_NAME}' for recreation")
-            # except Exception:
-            #     pass
-            
-            queue = await channel.declare_queue(
-                QUEUE_NAME,
-                durable=True,
-                exclusive=False,
-                auto_delete=False,
-                arguments={
-                    "x-max-length-bytes": QUEUE_MAX_BYTES,
-                    "x-queue-type": "quorum"
-                },
-            )
-            logger.info(f"RabbitMQ queue '{QUEUE_NAME}' declared.")
-            
-            await queue.bind(exchange)
-            logger.info(f"RabbitMQ queue '{QUEUE_NAME}' bound to exchange '{EXCHANGE_NAME}'.")
-            
-            logger.info("Starting message consumption...")
-            
-            # 3. Consume messages using iterator (blocks waiting for messages)
-            async with queue.iterator() as queue_iter:
-                async for message in queue_iter:
-                    if stop_event.is_set():
-                        logger.info("Stop requested. Breaking consume loop.")
-                        break
-                    
-                    try:
-                        await process_message(message)
-                    except Exception as e:
-                        logger.error(f"Error processing message: {e}")
-                        # Continue to next message (processing errors don't trigger reconnect)
-                        continue
-            
+            connection, queue = await setup_rabbitmq(rb_url, name)
+
+            logger.info(f"Starting message consumption from {name}...")
+            await consume_queue(queue, name)
+
         except asyncio.CancelledError:
-            logger.info("Consumer cancelled; shutting down.")
+            logger.info(f"Consumer cancelled from {name}; shutting down.")
             raise
-        except (aio_pika.exceptions.AMQPConnectionError,
-                aio_pika.exceptions.ConnectionClosed,
-                aio_pika.exceptions.ChannelClosed,
-                ChannelInvalidStateError) as e:
-            logger.warning(f"RabbitMQ connection/channel lost: {e}. Reconnecting...")
+
+        except (
+            aio_pika.exceptions.AMQPConnectionError,
+            aio_pika.exceptions.ConnectionClosed,
+            aio_pika.exceptions.ChannelClosed,
+            ChannelInvalidStateError,
+        ) as e:
+            logger.warning(f"RabbitMQ connection/channel lost from {name}: {e}. Reconnecting...")
+
         except Exception as e:
-            logger.exception(f"Unexpected error: {e}. Reconnecting...")
+            logger.exception(f"Unexpected error from {name}: {e}. Reconnecting...")
+
         finally:
             logger.info("Cleaning up RabbitMQ resources...")
             if connection and not connection.is_closed:
                 await connection.close()
-        
+
         if not stop_event.is_set():
             logger.info(f"Waiting {RABBITMQ_RECONNECT_INTERVAL}s before reconnecting...")
             await asyncio.sleep(RABBITMQ_RECONNECT_INTERVAL)
-    
+
     logger.info("Consumer stopped.")
-    
+
+
+
+async def parse_rows(rb_url: str):
+    """
+    Loads camera rows from DB and prepares DB metadata for this RabbitMQ URL.
+    Raises an exception if no data is available.
+    """
+    logger.info("Fetching DB camera rows for %s", rb_url)
+
+    rows = await sync_to_async(get_all_from_db)()
+    db_data = process_camera_rows(rows)
+
+    if not db_data:
+        raise RuntimeError(
+            f"No camera data available for watermarking. Consumer ({rb_url}) exiting."
+        )
+
+    logger.info("DB camera data loaded for %s (%d rows).", rb_url, len(db_data))
+    return db_data
+
+
+async def run_consumer():
+    """
+    Launch consumers for Gold and GoldDR in parallel.
+    Each consumer listens to its own RabbitMQ instance.
+    """
+    gold_url = os.getenv("RABBITMQ_URL_GOLD")
+    golddr_url = os.getenv("RABBITMQ_URL_GOLDDR")
+
+    if not gold_url and not golddr_url:
+        raise RuntimeError("No RabbitMQ URLs configured. At least one is required.")
+
+    tasks = []
+
+    if gold_url:
+        logger.info("Starting GOLD consumer...")
+        tasks.append(asyncio.create_task(consume_from(gold_url, "GOLD")))
+        # pass
+
+    if golddr_url:
+        logger.info("Starting GOLDDR consumer...")
+        tasks.append(asyncio.create_task(consume_from(golddr_url, "GOLDDR")))
+        # pass
+
+    logger.info("All configured RabbitMQ consumers started.")
+
+    # Wait until stop_event is set (SIGTERM / SIGINT)
+    try:
+        await stop_event.wait()
+    finally:
+        logger.info("Stop event received; cancelling consumers...")
+        for task in tasks:
+            task.cancel()
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+        logger.info("All consumers stopped.")
+
+def shutdown():
+    """Signal handler to gracefully stop the consumer."""
+    logger.info("Received shutdown signal.")
+    stop_event.set()
+
 async def process_message(message: aio_pika.IncomingMessage):
     """Process a single message from the queue."""
     async with message.process(ignore_processed=True):
@@ -277,10 +288,6 @@ def safe_db_call(func, *args, **kwargs):
     connection.ensure_connection()
     return func(*args, **kwargs)
 
-def shutdown():
-    """Signal handler to gracefully stop the consumer."""
-    logger.info("Received shutdown signal.")
-    stop_event.set()
 
 def process_camera_rows(rows):
     if not rows:
@@ -554,7 +561,7 @@ def update_webcam(camera_id, timestamp, webcam):
     camera_status = calculate_camera_status(camera_id, time_now_utc)
 
 
-    camera, created = Webcam.objects.update_or_create(
+    camera, _ = Webcam.objects.update_or_create(
         id=camera_id,
         defaults={
             "name": f"{webcam.get('cam_internet_name', '')}",

--- a/src/backend/apps/consumer/tests/test_processor.py
+++ b/src/backend/apps/consumer/tests/test_processor.py
@@ -1,9 +1,12 @@
-from unittest.mock import patch, MagicMock
+import os
+from unittest.mock import patch, MagicMock, AsyncMock
 from datetime import datetime
 import io
 
 from django.test import TestCase
 from django.core.cache import cache
+import asyncio
+
 
 from apps.consumer.processor import (
     process_camera_rows,
@@ -15,6 +18,7 @@ from apps.consumer.processor import (
     refresh_camera_cache,
 )
 from apps.webcam.models import Webcam
+from apps.consumer import processor
 
 
 class MockCameraRow:
@@ -211,3 +215,329 @@ class TestRefreshCameraCache(TestCase):
 
         mock_get_db.assert_called_once_with('1')
         mock_process.assert_called_once()
+
+class TestRabbitMQConsumer(TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    # setup_rabbitmq tests
+    @patch("apps.consumer.processor.aio_pika.connect_robust")
+    def test_setup_rabbitmq_success(self, mock_connect):
+        from apps.consumer.processor import setup_rabbitmq
+
+        mock_connection = AsyncMock()
+        mock_channel = AsyncMock()
+        mock_queue = AsyncMock()
+
+        mock_connect.return_value = mock_connection
+        mock_connection.channel.return_value = mock_channel
+        mock_channel.declare_queue.return_value = mock_queue
+
+        async def run_test():
+            conn, queue = await setup_rabbitmq(os.getenv("RABBITMQ_URL_GOLD"), "GOLD")
+            return conn, queue
+
+        conn, queue = asyncio.run(run_test())
+
+        self.assertEqual(conn, mock_connection)
+        self.assertEqual(queue, mock_queue)
+        mock_connect.assert_called_once()
+
+    # consume_queue tests
+    @patch("apps.consumer.processor.process_message", new_callable=AsyncMock)
+    def test_consume_queue_processes_messages(self, mock_process):
+        from apps.consumer.processor import consume_queue
+
+        mock_queue = MagicMock()
+
+        mock_message = MagicMock()
+
+        # Create async iterator
+        async def async_iter():
+            yield mock_message
+
+        # Mock context manager
+        mock_iterator = MagicMock()
+        mock_iterator.__aenter__ = AsyncMock(return_value=async_iter())
+        mock_iterator.__aexit__ = AsyncMock(return_value=None)
+
+        mock_queue.iterator.return_value = mock_iterator
+
+        async def run_test():
+            await consume_queue(mock_queue, "GOLD")
+
+        asyncio.run(run_test())
+
+        mock_process.assert_called_once_with(mock_message)
+
+    @patch("apps.consumer.processor.process_message", new_callable=AsyncMock)
+    def test_consume_queue_handles_processing_error(self, mock_process):
+        from apps.consumer.processor import consume_queue
+
+        mock_queue = MagicMock()
+        mock_message = MagicMock()
+
+        # Async iterator that yields one message
+        async def async_iter():
+            yield mock_message
+
+        # Mock async context manager
+        mock_iterator = MagicMock()
+        mock_iterator.__aenter__ = AsyncMock(return_value=async_iter())
+        mock_iterator.__aexit__ = AsyncMock(return_value=None)
+
+        mock_queue.iterator.return_value = mock_iterator
+
+        # Simulate processing failure
+        mock_process.side_effect = Exception("boom")
+
+        async def run_test():
+            await consume_queue(mock_queue, "GOLD")
+
+        asyncio.run(run_test())
+
+        mock_process.assert_called_once_with(mock_message)
+
+    # consume_from tests
+    @patch("apps.consumer.processor.consume_queue", new_callable=AsyncMock)
+    @patch("apps.consumer.processor.setup_rabbitmq", new_callable=AsyncMock)
+    def test_consume_from_success_flow(self, mock_setup, mock_consume):
+        from apps.consumer.processor import consume_from, stop_event
+
+        stop_event.clear()
+
+        mock_connection = AsyncMock()
+        mock_connection.is_closed = False
+        mock_queue = MagicMock()
+
+        mock_setup.return_value = (mock_connection, mock_queue)
+
+        async def run_test():
+            # stop after first iteration
+            async def stop_later():
+                await asyncio.sleep(0.01)
+                stop_event.set()
+
+            await asyncio.gather(
+                consume_from(os.getenv("RABBITMQ_URL_GOLD"), "GOLD"),
+                stop_later()
+            )
+
+        asyncio.run(run_test())
+
+        mock_setup.assert_called_once()
+        mock_consume.assert_called_once()
+        mock_connection.close.assert_called_once()
+
+        stop_event.clear()
+
+    @patch("apps.consumer.processor.setup_rabbitmq", new_callable=AsyncMock)
+    def test_consume_from_reconnect_on_error(self, mock_setup):
+        from apps.consumer.processor import consume_from, stop_event
+
+        stop_event.clear()
+
+        mock_setup.side_effect = Exception("connection error")
+
+        async def run_test():
+            async def stop_later():
+                await asyncio.sleep(0.01)
+                stop_event.set()
+
+            await asyncio.gather(
+                consume_from(os.getenv("RABBITMQ_URL_GOLD"), "GOLD"),
+                stop_later()
+            )
+
+        asyncio.run(run_test())
+
+        self.assertTrue(mock_setup.called)
+
+        stop_event.clear()
+
+    @patch("apps.consumer.processor.setup_rabbitmq", new_callable=AsyncMock)
+    @patch("apps.consumer.processor.consume_queue", new_callable=AsyncMock)
+    def test_consume_from_closes_connection(self, mock_consume, mock_setup):
+        from apps.consumer.processor import consume_from, stop_event
+
+        stop_event.clear()
+
+        mock_connection = AsyncMock()
+        mock_connection.is_closed = False
+        mock_queue = MagicMock()
+
+        mock_setup.return_value = (mock_connection, mock_queue)
+
+        async def run_test():
+            async def stop_later():
+                await asyncio.sleep(0.01)
+                stop_event.set()
+
+            await asyncio.gather(
+                consume_from(os.getenv("RABBITMQ_URL_GOLD"), "GOLD"),
+                stop_later()
+            )
+
+        asyncio.run(run_test())
+
+        mock_connection.close.assert_called_once()
+
+        stop_event.clear()
+
+    def test_run_consumer_no_urls_raises(self):
+        from apps.consumer.processor import run_consumer, stop_event
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError):
+                asyncio.run(run_consumer())
+
+    @patch("apps.consumer.processor.consume_from", new_callable=AsyncMock)
+    def test_run_consumer_gold_only(self, mock_consume):
+        import asyncio
+        from apps.consumer import processor
+
+        reset_stop_event()
+
+        with patch.dict(os.environ, {
+            "RABBITMQ_URL_GOLD": "amqp://gold"
+        }, clear=True):
+
+            async def run_test():
+                consumer_task = asyncio.create_task(
+                    processor.run_consumer()
+                )
+
+                # give consumer time to start
+                await asyncio.sleep(0.01)
+
+                processor.stop_event.set()
+
+                await consumer_task
+
+            asyncio.run(run_test())
+
+        mock_consume.assert_called_once_with("amqp://gold", "GOLD")
+
+
+    @patch("apps.consumer.processor.consume_from", new_callable=AsyncMock)
+    def test_run_consumer_both_urls(self, mock_consume):
+        reset_stop_event()
+
+        with patch.dict(os.environ, {
+            "RABBITMQ_URL_GOLD": "amqp://gold",
+            "RABBITMQ_URL_GOLDDR": "amqp://golddr"
+        }):
+            async def run_test():
+                consumer_task = asyncio.create_task(
+                    processor.run_consumer()
+                )
+
+                # give consumer time to start
+                await asyncio.sleep(0.01)
+
+                processor.stop_event.set()
+
+                await consumer_task
+
+            asyncio.run(run_test())
+
+        self.assertEqual(mock_consume.call_count, 2)
+
+
+    @patch("apps.consumer.processor.consume_from", new_callable=AsyncMock)
+    def test_run_consumer_cancels_tasks(self, mock_consume):
+        reset_stop_event()
+
+        with patch.dict(os.environ, {
+            "RABBITMQ_URL_GOLD": "amqp://gold"
+        }, clear=True):
+
+            async def run_test():
+                consumer_task = asyncio.create_task(
+                    processor.run_consumer()
+                )
+
+                # give consumer time to start
+                await asyncio.sleep(0.01)
+
+                processor.stop_event.set()
+
+                await consumer_task
+
+            asyncio.run(run_test())
+
+        mock_consume.assert_called_once()
+
+    def test_shutdown_sets_event(self):
+        from apps.consumer.processor import shutdown, stop_event
+
+        reset_stop_event()
+
+        shutdown()
+
+        self.assertTrue(stop_event.is_set())
+
+class TestParseRows(TestCase):
+
+    @patch("apps.consumer.processor.process_camera_rows")
+    @patch("apps.consumer.processor.get_all_from_db")
+    def test_parse_rows_success(self, mock_get_db, mock_process):
+        from apps.consumer.processor import parse_rows
+
+        mock_get_db.return_value = ["row1", "row2"]
+        mock_process.return_value = [{"camera": 1}, {"camera": 2}]
+
+        async def run_test():
+            result = await parse_rows(os.getenv("RABBITMQ_URL_GOLD"))
+
+            self.assertEqual(result, [{"camera": 1}, {"camera": 2}])
+
+        asyncio.run(run_test())
+
+        mock_get_db.assert_called_once()
+        mock_process.assert_called_once_with(["row1", "row2"])
+
+    @patch("apps.consumer.processor.process_camera_rows")
+    @patch("apps.consumer.processor.get_all_from_db")
+    def test_parse_rows_empty_raises(self, mock_get_db, mock_process):
+        from apps.consumer.processor import parse_rows
+
+        mock_get_db.return_value = []
+        mock_process.return_value = []
+
+        async def run_test():
+            with self.assertRaises(RuntimeError) as ctx:
+                await parse_rows(os.getenv("RABBITMQ_URL_GOLD"))
+
+            self.assertIn("No camera data available", str(ctx.exception))
+
+        asyncio.run(run_test())
+
+        mock_get_db.assert_called_once()
+        mock_process.assert_called_once_with([])
+
+    @patch("apps.consumer.processor.logger")
+    @patch("apps.consumer.processor.process_camera_rows")
+    @patch("apps.consumer.processor.get_all_from_db")
+    def test_parse_rows_logs_success(self, mock_get_db, mock_process, mock_logger):
+        from apps.consumer.processor import parse_rows
+
+        mock_get_db.return_value = ["row1"]
+        mock_process.return_value = [{"camera": 1}]
+
+        async def run_test():
+            await parse_rows(os.getenv("RABBITMQ_URL_GOLD"))
+
+        asyncio.run(run_test())
+
+        mock_logger.info.assert_called()
+
+def reset_stop_event():
+    import asyncio
+    from apps.consumer import processor
+
+    processor.stop_event = asyncio.Event()


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5164

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Restart consumer pod, and make sure RabbitMQ on GOLD is available.
2. Verify if the service is connecting to GOLD and GOLDDR in parallel, by looking at the logs like this:
2026-04-27 10:19:28,590 [INFO] Starting GOLD consumer...
2026-04-27 10:19:28,590 [INFO] Starting GOLDDR consumer...
2026-04-27 10:19:28,590 [INFO] All configured RabbitMQ consumers started.
2026-04-27 10:19:28,710 [INFO] RabbitMQ connection established for GOLD.
2026-04-27 10:19:28,741 [INFO] RabbitMQ connection established for GOLDDR.
2026-04-27 10:19:28,784 [INFO] RabbitMQ channel created for GOLD.
2026-04-27 10:19:28,926 [INFO] RabbitMQ channel created for GOLDDR.
2026-04-27 10:19:28,946 [INFO] Starting message consumption from GOLD...
2026-04-27 10:19:29,047 [INFO] Starting message consumption from GOLDDR...
3. Verify if the consumer is connecting to by GOLD by default.
4. Shut down RabbitMQ on GOLD, verify if the consumer still can consume images from GOLDDR.

---

### 🔍 Reviewer Checklist
- [x] Reviewed code for logic and cleanliness
- [x] Re-tested desktop/mobile in local or dev envs
- [x] Verified no new console warnings/errors
- [x] Confirmed that any new env variables are understood/documented