### PR TITLE
DBC22-6337: return populated list and log errors when exception thrown

### DIFF
--- a/src/backend/apps/feed/client.py
+++ b/src/backend/apps/feed/client.py
@@ -270,7 +270,7 @@ class FeedClient:
             return cameras
 
         except Exception as e:
-            logger.error(f"Failed to query camera from Webcam database: {e}")
+            logging.exception(f"Failed to query camera from Webcam database: {e}")
             return []
         
     # Events
@@ -322,11 +322,11 @@ class FeedClient:
 
         area_code_endpoint = settings.DRIVEBC_SAWSX_API_BASE_URL + '/ec/list/fcstareas'
 
+        json_objects = []
         try:
             response = self.make_weather_request(area_code_endpoint)
             response.raise_for_status()
-            json_response = response.json()
-            json_objects = []
+            json_response = response.json()         
 
             for entry in json_response:
                 # only high elevation ares will return anything; skip others
@@ -358,8 +358,9 @@ class FeedClient:
                         latitude = float(location.get('Latitude').replace('N', ''))
                         longitude = float('-' + location.get('Longitude').replace('W', ''))
                     except ValueError:
-                        logger.error(f"coudn't covert coords for {area_code}: {location}")
+                        logging.exception(f"coudn't covert coords for {area_code}: {location}")
                         latitude = longitude = None
+                        continue
 
                     issued = data.get("ForecastIssuedUtc")
                     if issued is not None:
@@ -395,12 +396,13 @@ class FeedClient:
                     })
 
                 except requests.RequestException as e:
-                    logger.error(f"Error making API call for Area Code {area_code}: {e}")
+                    logging.exception(f"Error making API call for Area Code {area_code}: {e}")
 
-            return json_objects
 
-        except requests.RequestException:
-            return Response("Error fetching data from weather API", status=500)
+        except requests.RequestException as e:
+            logging.exception(f"Error fetching data from weather API: {e}")
+        
+        return json_objects  
 
     # Current Weather
     def get_current_weather_list_feed(self, serializer_cls, token):
@@ -664,7 +666,7 @@ class FeedClient:
 
             return result
         except httpx.HTTPStatusError as e:
-            logger.error(
+            logging.exception(
                 "DMS WFS request failed",
                 extra={
                     "url": str(e.request.url),

--- a/src/backend/apps/feed/tests/test_feed_client.py
+++ b/src/backend/apps/feed/tests/test_feed_client.py
@@ -520,7 +520,7 @@ class TestFeedClientHighElevation(BaseTest):
         mock_weather_request.side_effect = requests.RequestException("Connection Error")
 
         result = self.client.get_high_elevation_forecast_list()
-        self.assertEqual(result.status_code, 500)
+        self.assertEqual(result, [])
 
     @patch('apps.feed.client.FeedClient.make_weather_request')
     def test_get_high_elevation_forecast_list_valid_issued_date(self, mock_weather_request):
@@ -537,6 +537,45 @@ class TestFeedClientHighElevation(BaseTest):
         result = self.client.get_high_elevation_forecast_list()
         self.assertEqual(len(result), 1)
         self.assertIsNotNone(result[0].get('issued_utc'))
+
+    @patch('apps.feed.client.FeedClient.make_weather_request')
+    def test_get_high_elevation_forecast_list_invalid_data(self, mock_weather_request):
+        """Test that valid items are returned and errors are logged when some entries have invalid data."""
+        
+        # Area list with one valid and one invalid entry
+        area_list_response = create_mock_response(200, [
+            {'AreaType': 'ECHIGHELEVN', 'AreaCode': 'ABC', 'AreaName': 'Valid Area'},
+            {'AreaType': 'ECHIGHELEVN', 'AreaCode': 'XYZ', 'AreaName': 'Invalid Area'},
+        ])
+
+        valid_forecast_response = create_mock_response(200, {
+            'Location': {'Name': {'Latitude': '50N', 'Longitude': '120W'}},
+            'ForecastIssuedUtc': '2024-01-01T12:00:00',
+            'ForecastGroup': {
+                'Forecasts': [
+                    {'Period': {'TextForecastName': 'Today'}, 'TextSummary': 'Sunny', 'AbbreviatedForecast': {'IconCode': {'Code': '00'}}}
+                ]
+            }
+        })
+
+        invalid_forecast_response = create_mock_response(200, {
+            'Location': {'Name': {'Latitude': 'INVALID', 'Longitude': 'INVALID'}},
+            'ForecastIssuedUtc': '2024-01-01T12:00:00',
+            'ForecastGroup': {'Forecasts': []},
+        })
+
+        mock_weather_request.side_effect = [area_list_response, valid_forecast_response, invalid_forecast_response]
+
+        with patch('apps.feed.client.logging.exception') as mock_log:
+            result = self.client.get_high_elevation_forecast_list()
+
+            # Only valid item is returned
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]['code'], 'ABC')
+
+            # Error was logged for the invalid item
+            mock_log.assert_called_once()
+            assert 'XYZ' in str(mock_log.call_args)
 
 
 class TestFeedClientCurrentWeather(BaseTest):


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **https://moti-imb.atlassian.net/browse/DBC22-6337

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [x] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Go to tasks pod, execute command: . /vault/secrets/secrets.env && python manage.py populate_hef
2. Verify no errors reported

---

### 🔍 Reviewer Checklist
- [x] Reviewed code for logic and cleanliness
- [x] Re-tested desktop/mobile in local or dev envs
- [x] Verified no new console warnings/errors
- [x] Confirmed that any new env variables are understood/documented