### PR TITLE
DBC22-6423: Update stats for otp change

### DIFF
--- a/src/backend/config/admin.py
+++ b/src/backend/config/admin.py
@@ -29,6 +29,7 @@ class DriveBCAdminSite(AdminSite):
     def index(self, request, extra_context=None):
         from apps.authentication.models import DriveBCUser, SavedRoutes, FavouritedCameras
         from email_log.models import Email
+        from allauth.socialaccount.models import SocialAccount
 
         extra = extra_context or {}
         thirty_days_ago = timezone.now() - timedelta(days=30)
@@ -43,17 +44,30 @@ class DriveBCAdminSite(AdminSite):
             'basic_bceid_users_count': DriveBCUser.objects.filter(
                 username__endswith='bceidbasic'
             ).count(),
-            'bceid_users_logged_in_last_30_days': DriveBCUser.objects.filter(
-                username__endswith='bceidbasic',
-                last_login__gte=thirty_days_ago
+            'bceid_users_logged_in_last_30_days': SocialAccount.objects.filter(
+                provider='bceid',
+                user__last_login__gte=thirty_days_ago
             ).count(),
-            'otp_users_count': DriveBCUser.objects.filter(
-                username__endswith='otp'
-            ).count(),
-            'otp_users_logged_in_last_30_days': DriveBCUser.objects.filter(
-                username__endswith='otp',
-                last_login__gte=thirty_days_ago
-            ).count(),
+            'otp_users_count': SocialAccount.objects.filter(
+                provider='otp'
+            ).values('user').distinct().count(),
+            'otp_users_logged_in_last_30_days': SocialAccount.objects.filter(
+                provider='otp',
+                user__last_login__gte=thirty_days_ago
+            ).values('user').distinct().count(),
+            'users_with_bceid_and_otp': SocialAccount.objects.filter(
+                provider='bceid'
+            ).filter(
+                user__socialaccount__provider='otp'
+            ).values('user').distinct().count(),
+            'new_bceid_users_last_30_days': SocialAccount.objects.filter(
+                provider='bceid_basic',
+                user__date_joined__gte=thirty_days_ago
+            ).values('user').distinct().count(),
+            'new_otp_users_last_30_days': SocialAccount.objects.filter(
+                provider='otp',
+                user__date_joined__gte=thirty_days_ago
+            ).values('user').distinct().count(),
             'saved_routes': SavedRoutes.objects.count(),
             'unique_users_with_saved_routes': SavedRoutes.objects.values('user').distinct().count(),
             'unique_users_with_saved_routes_and_notifications': SavedRoutes.objects.filter(

--- a/src/backend/templates/admin/index.html
+++ b/src/backend/templates/admin/index.html
@@ -16,12 +16,24 @@
           <td>{{ counts.bceid_users_logged_in_last_30_days }}</td>
         </tr>
         <tr class="model-group">
+          <th style="padding-left: 2em;">New BCeID Users (Last 30 Days)</th>
+          <td>{{ counts.new_bceid_users_last_30_days }}</td>
+        </tr>
+        <tr class="model-group">
           <th>OTP Users Count</th>
           <td>{{ counts.otp_users_count }}</td>
         </tr>
         <tr class="model-group">
           <th style="padding-left: 2em;">OTP Users Logged In (Last 30 Days)</th>
           <td>{{ counts.otp_users_logged_in_last_30_days }}</td>
+        </tr>
+        <tr class="model-group">
+          <th style="padding-left: 2em;">New OTP Users (Last 30 Days)</th>
+          <td>{{ counts.new_otp_users_last_30_days }}</td>
+        </tr>
+        <tr class="model-group">
+          <th>Users with BCeID and OTP Accounts</th>
+          <td>{{ counts.users_with_bceid_and_otp }}</td>
         </tr>
         <!-- Saved Routes Section -->
         <tr class="model-group">


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6423

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Go to django-admin page
2. Confirm that you see the new user count for BCeID and OTP
3. Confirm you see the count of users with BCeID and OTP
4. Confirm that you are getting values for OTP user count and BCEID users. (note that if an underlying user has 2 OTP social accounts, they will only get counted once with this change because of the sub change they get two social account.)

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented