### PR TITLE
DBC22-6210: fixed dms filter layer spinner not showing when refreshing

### DIFF
--- a/src/frontend/src/Components/map/MapWrapper.js
+++ b/src/frontend/src/Components/map/MapWrapper.js
@@ -230,7 +230,8 @@ export default function MapWrapper(props) {
       ferries: reloadFerries,
       weathers: reloadLocalWeathers || reloadRegionalWeathers,
       restStops: reloadRestStops,
-      wildfires: reloadWildfires
+      wildfires: reloadWildfires,
+      dms: reloadDms
     });
 
     handleLoad(() => dataLoaders.loadCameras(routeData, reloadCameras ? null : camerasRef.current, dispatch, workerRef.current), displayError);


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6210

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Toggle on the Dynamic message signs layer.
2. Open developer tools and filter for /dms/.
3. Wait for an update to happen while monitoring the Map layer toggle for DMS.
4. Alternately, refresh the page.
5. Verify when the DMS layer updates for any reason, the icon firefly shows a loading spinner.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented