### PR TITLE
DBC22-6169: access webcam db directly when fetching camera is_on status

### DIFF
--- a/src/backend/apps/consumer/tasks.py
+++ b/src/backend/apps/consumer/tasks.py
@@ -3,6 +3,8 @@ import io
 
 from apps.consumer.processor import process_camera_rows, watermark, blank_out_image, save_watermarked_image_to_pvc, save_watermarked_image_to_drivebc_pvc, delete_watermarked_image_from_pvc, delete_offline_webcam_records
 from datetime import datetime
+
+from apps.webcam.models import Webcam
 from .db import get_all_from_db
 import pytz
 from PIL import Image
@@ -38,3 +40,8 @@ def generate_offline_camera_images():
                 async_to_sync(delete_offline_webcam_records)(camera_id)
                 # Save blank image for current image displaying
                 save_watermarked_image_to_drivebc_pvc(camera_id, watermarked, False)
+            # Update postgres db is_on status to False for offline cameras
+            Webcam.objects.filter(id=camera['id']).update(is_on=False)
+        else:
+            # Update postgres db is_on status to True for online cameras
+            Webcam.objects.filter(id=camera['id']).update(is_on=True)

--- a/src/backend/apps/webcam/admin.py
+++ b/src/backend/apps/webcam/admin.py
@@ -15,6 +15,7 @@ class WebcamAdmin(admin.GISModelAdmin):
     gis_widget = DriveBCMapWidget
     change_form_template = "admin/timelapse.html"  # custom template
 
+
     def change_view(self, request, object_id, form_url='', extra_context=None):
         webcam = self.get_object(request, object_id)
         extra_context = extra_context or {}
@@ -34,6 +35,9 @@ class WebcamAdmin(admin.GISModelAdmin):
             extra_context["default_end_date"] = now_local.date().isoformat()
             extra_context["default_end_time"] = "23:59"
 
+
+        
+        
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):

--- a/src/backend/apps/webcam/serializers.py
+++ b/src/backend/apps/webcam/serializers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from rest_framework import serializers
 
 
+
 class WebcamSerializer(serializers.ModelSerializer):
     name = serializers.CharField(required=False, allow_blank=True)
     caption = serializers.CharField(required=False, allow_blank=True)
@@ -21,6 +22,7 @@ class WebcamSerializer(serializers.ModelSerializer):
             "created_at",
             "modified_at",
         )
+
 
     def to_representation(self, instance):
         data = super().to_representation(instance)


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6169

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev
2. Turn on/off a specific camera.
3. Verify frontend reflect the is_on changes, it usually takes 2-3 seconds to reflect the camera is_on status when the camera is turned on/off from the control panel. 

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented