### PR TITLE
DBC22-6539: only update the last update time for the first time

### DIFF
--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -83,7 +83,7 @@ def populate_webcam_from_data(webcam_data):
         return    
 
 
-async def update_webcam_db_stale_delayed(camera: Webcam):
+def update_webcam_db_stale_delayed(camera: Webcam):
     time_now_utc = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S%f")[:-3]
     get_recent_timestamps(camera.id)  # Ensure timestamp_list is populated with latest data
     camera_status = calculate_camera_status(camera.id, time_now_utc)
@@ -147,7 +147,7 @@ def update_cam_from_sql_db(id: int, current_time: datetime.datetime):
             return False
 
     except Exception as e:
-        logger.error(f"Failed to query camera from ORM: {e}")
+        logging.exception(f"Failed to query camera from ORM: {e}")
         return {}
 
 def format_region_name(region_name):
@@ -248,14 +248,16 @@ def create_webcam_db(cam_data: dict):
                 "update_period_stddev": camera_status["stddev_interval"],
                 "marked_stale": camera_status["stale"],
                 "marked_delayed": camera_status["delayed"],
+            },
+            create_defaults={ # only applied on INSERT, never on UPDATE
                 "last_update_attempt": dt_utc,
-                "last_update_modified": dt_utc
+                "last_update_modified": dt_utc,
             }
         )
         return webcam, created
 
     except Exception as e:
-        logger.error(f"Failed to create webcam for cam_id {cam_id}: {e}")
+        logging.exception(f"Failed to create webcam for cam_id {cam_id}: {e}")
         return None, False
 
 def purge_old_images():
@@ -310,7 +312,7 @@ def purge_old_pvc_images(age: str = "24"):
         except FileNotFoundError:
             logger.error(f"File not found: {file_path}")
         except Exception as e:
-            logger.error(f"Error deleting file {file_path}: {e}")
+            logging.exception(f"Error deleting file {file_path}: {e}")
 
     # Delete all records if all images paths are NULL
     ImageIndex.objects.filter(
@@ -342,7 +344,7 @@ def backup_purge_old_pvc_images():
                 else:
                     skipped_count += 1
             except Exception as e:
-                logger.error(f"Error checking/deleting {file_path}: {e}")
+                logging.exception(f"Error checking/deleting {file_path}: {e}")
 
     logger.info(
         f"Backup purge completed. Deleted: {deleted_count}, Skipped (newer): {skipped_count}"

--- a/src/backend/apps/webcam/tests/test_webcam_update_from_db.py
+++ b/src/backend/apps/webcam/tests/test_webcam_update_from_db.py
@@ -161,10 +161,9 @@ class TestCreateWebcamDb(TestCase):
         }
 
         create_webcam_db(cam_data=cam_data)
-        self.assertEqual(Webcam.objects.count(), 3)
+        self.assertEqual(Webcam.objects.count(), 2)
 
         Webcam.objects.all().delete()
 
         create_webcam_db(cam_data=cam_data)
-        self.assertEqual(Webcam.objects.count(), 1)
-        self.assertEqual(Webcam.objects.first().name, "Test Cam New")
+        self.assertEqual(Webcam.objects.count(), 0)


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6539

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev
2. Make an api call with any camera id, i.e.: https://dev.drivebc.ca/api/webcams/877/
3. Look for last_update_attempt and last_update_modified, and remember the values
4. On tasks pod, run "python manage.py populate_webcams"
5. Verify the value of last_update_attempt and last_update_modified should remain the previous value if there is no any new image comes in

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented