### PR TITLE
DBC22-6243: remain focused for current cammeras on mini map

### DIFF
--- a/src/frontend/src/Components/map/handlers/click.js
+++ b/src/frontend/src/Components/map/handlers/click.js
@@ -30,6 +30,8 @@ import {
   dmsNorthStyles
 } from '../../data/featureStyleDefinitions.js';
 
+let highlighted_camera_list = []
+
 // Click states
 export const resetClickedStates = (
   targetFeature,
@@ -183,6 +185,12 @@ export const resetClickedStates = (
         updateClickedFeature(null);
         break;
     }
+    if (isCamDetail && targetFeature && targetFeature.get('type') === 'camera') {
+      if (highlighted_camera_list.length > 0) {     
+          highlighted_camera_list[0].setCameraStyle('static');
+          highlighted_camera_list[0].set('clicked', false); 
+        }
+    }
   }
 };
 
@@ -221,12 +229,27 @@ const camClickHandler = (
   updateReferenceFeature,
   mapContext
 ) => {
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if ((clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')
+    || (clickedFeatureRef.current && (clickedFeatureRef.current.values_.type != feature.values_.type))) {
+    resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+  }
+
+  if (highlighted_camera_list.length > 0) {
+      console.log("highlighted_camera_list: ", highlighted_camera_list)
+      resetClickedStates(
+      feature,
+      highlighted_camera_list[0],
+      updateClickedFeature,
+      isCamDetail,
+    );
+    highlighted_camera_list = [];
+    highlighted_camera_list.push(feature);
+    }
 
   // set new clicked camera feature
   feature.setCameraStyle('active');
@@ -270,12 +293,17 @@ export const eventClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+      resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+  }
 
   // set new clicked event feature
   setEventStyle(feature, 'active');
@@ -300,12 +328,17 @@ export const ferryClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+      resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+  }
 
   const styles = feature.get('coastal') ? coastalFerryStyles : ferryStyles;
 
@@ -321,13 +354,19 @@ const weatherClickHandler = (
   updateClickedFeature,
   isCamDetail,
 ) => {
-  // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+    // reset previous clicked feature
+    resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+  }
+  else {
+     highlighted_camera_list.push(clickedFeatureRef.current);
+
+  }
 
   // set new clicked local weather feature
   feature.setStyle(roadWeatherStyles['active']);
@@ -341,13 +380,20 @@ const regionalClickHandler = (
   updateClickedFeature,
   isCamDetail,
 ) => {
-  // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+    // reset previous clicked feature
+    resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+    
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+
+  }
 
   // set new clicked regional weather feature
   const warnings = feature.get('warnings');
@@ -363,12 +409,18 @@ const hefClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+      resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+  }
 
   // set new clicked hef weather feature
   const warnings = feature.get('warnings');
@@ -384,12 +436,17 @@ const restStopClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+      resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+  }
 
   // set new clicked rest stop feature
   const isClosed = isRestStopClosed(feature.values_.properties);
@@ -418,12 +475,17 @@ const routeClickHandler = (
   updateClickedFeature,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    false,
-  );
+  if (!(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+      resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      false,
+    );
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+  }
 
   // set new clicked route feature
   feature.set('clicked', true);
@@ -437,12 +499,14 @@ const borderCrossingClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+    resetClickedStates(
+        feature,
+        clickedFeatureRef,
+        updateClickedFeature,
+        isCamDetail,
+      );
+  }
 
   // set new clicked border crossing feature
   feature.setStyle(borderCrossingStyles['active']);
@@ -477,12 +541,14 @@ export const wildfireClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!isCamDetail || !(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+    resetClickedStates(
+        feature,
+        clickedFeatureRef,
+        updateClickedFeature,
+        isCamDetail,
+      );
+  }
 
   const isCentroidFeature = feature.getGeometry().getType() === 'Point';
 
@@ -722,13 +788,18 @@ export const dmsClickHandler = (
   isCamDetail,
 ) => {
   // reset previous clicked feature
-  resetClickedStates(
-    feature,
-    clickedFeatureRef,
-    updateClickedFeature,
-    isCamDetail,
-  );
+  if (!(clickedFeatureRef.current && clickedFeatureRef.current.values_.type == 'camera')) {
+      resetClickedStates(
+      feature,
+      clickedFeatureRef,
+      updateClickedFeature,
+      isCamDetail,
+    );
 
+  }
+  else {
+    highlighted_camera_list.push(clickedFeatureRef.current);
+  }
   if (feature.getProperties().roadway_direction === 'Eastbound') {
     feature.setStyle(dmsEastStyles['active']);
   }

--- a/src/frontend/src/Components/map/handlers/click.js
+++ b/src/frontend/src/Components/map/handlers/click.js
@@ -240,7 +240,6 @@ const camClickHandler = (
   }
 
   if (highlighted_camera_list.length > 0) {
-      console.log("highlighted_camera_list: ", highlighted_camera_list)
       resetClickedStates(
       feature,
       highlighted_camera_list[0],


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6243

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev.
2. Turn on any layers that can be switched between cameras and any other object icons.
3. Open a camera detail page, looking at the focused camera icon on the mini map.
4. i.e., if you turned regional weather, roadside weather layers on, click other icons, the highlighted camera icon should be highlighted still, to show the current camera is focused, to allow the user know which camera he/she is looking at, other icons got clicked also will be highlighted as well.
5. Verify this behavior does not happen on main map view, only one icon get focus when switching between icons.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented