### PR TITLE
DBC-6331: convert srid to 4326 that frontend expected

### DIFF
--- a/src/backend/apps/cms/views.py
+++ b/src/backend/apps/cms/views.py
@@ -54,6 +54,11 @@ class CMSViewSet(viewsets.ReadOnlyModelViewSet):
             if latest_revision and latest_revision.created_at > obj.last_published_at:
                 obj = latest_revision.as_object()
 
+                # Revision geometry may be stored as SRID=3857 (Web Mercator),
+                # but the frontend expects SRID=4326 (WGS84) — normalize it.
+                if obj.geometry and obj.geometry.srid != 4326:
+                    obj.geometry.transform(4326)
+
         return obj
 
 


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6331

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. This issue happens when the user created a new advisory and published, then updated it and saved to draft, the preview page will be missing the map.
2. Deploy to dev.
3. Go to drivebc-cms admin panel to create a new advisory, and publish it.
4. Edit that new created advisory but don't publish it, just save as draft.
5. Copy the preview URL to verify the frontend shows the map correctly.

---

### 🔍 Reviewer Checklist
- [x] Reviewed code for logic and cleanliness
- [x] Re-tested desktop/mobile in local or dev envs
- [x] Verified no new console warnings/errors
- [x] Confirmed that any new env variables are understood/documented