### PR TITLE
DBC22-6183: push esri message to right when side panel open

### DIFF
--- a/src/frontend/src/App.scss
+++ b/src/frontend/src/App.scss
@@ -626,3 +626,9 @@ button.text-only-btn {
     content: none !important;
   }
 }
+
+.side-panel.open ~ .map .ol-attribution.attribution-control,
+.map-container:has(.side-panel.open) .ol-attribution.attribution-control {
+  left: 420px;
+  transition: left 0.3s ease;
+}


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6183

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev.
2. Go to main map and click on the "i" to open esri attribute message.
3. Click on any icon to open a side panel.
4. Verify the esri message can be pushed to right and visible when side panel is open.
5. Close the side panel, verify the esri attribute message and be pushed back to the bottom left.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented