### PR TITLE
DBC22-6431: auto open advisory panel on initial load with shared link

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -690,6 +690,29 @@ export default function DriveBCMap(props) {
     };
   }, []);
 
+  // Auto-open panel from URL params on initial load
+  useEffect(() => {
+    if (!mapRendered) return;
+
+    const type = searchParams.get('type');
+    const id = searchParams.get('id');
+
+    if (!type || !id) return;
+
+    if (type === 'advisory') {
+      const advisoryData = filteredAdvisories?.find(a => a.id === parseInt(id));
+      if (advisoryData) {
+        setTimeout(() => {
+          const olFeature = new Feature();
+          olFeature.set('type', 'advisory');
+          olFeature.set('id', advisoryData.id);
+          olFeature.set('data', advisoryData);
+          updateClickedFeature(olFeature);
+        }, 500);
+      }
+    }
+  }, [mapRendered]);
+
   /* Map operations on location search */
   useEffect(() => {
     if (searchLocationFrom && searchLocationFrom.length) {
@@ -996,9 +1019,11 @@ export default function DriveBCMap(props) {
   useEffect(() => {
     if (searchParamInitialized.current) {
       if (!clickedFeature) {
-        searchParams.delete('type');
+        if (searchParams.get('type') !== 'advisory') {
+          searchParams.delete('type');
+          searchParams.delete('id');
+        }
         searchParams.delete('display_category');
-        searchParams.delete('id');
         searchParams.delete('camIndex');
         setSearchParams(searchParams, { replace: true });
       }

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -700,6 +700,8 @@ export default function DriveBCMap(props) {
     if (!type || !id) return;
 
     if (type === 'advisory') {
+      // Advisories haven't loaded yet — wait for them, don't give up.
+      if (!filteredAdvisories || !filteredAdvisories.length) return;
       const advisoryData = filteredAdvisories?.find(a => a.id === parseInt(id));
       if (advisoryData) {
         setTimeout(() => {
@@ -710,8 +712,12 @@ export default function DriveBCMap(props) {
           updateClickedFeature(olFeature);
         }, 500);
       }
+      else {
+        // Advisories loaded but this id genuinely doesn't exist
+        setStaleLinkMessage(true);
+      }
     }
-  }, [mapRendered]);
+  }, [mapRendered, filteredAdvisories]);
 
   /* Map operations on location search */
   useEffect(() => {

--- a/src/frontend/src/Components/map/panels/index.js
+++ b/src/frontend/src/Components/map/panels/index.js
@@ -97,7 +97,7 @@ export const resizePanel = (panelRef, clickedFeature, setMaximizedPanel) => {
 
 export const togglePanel = (panelRef, resetClickedStates, clickedFeatureRef, updateClickedFeature, pushMargins, searchedRoutes) => {
   if (searchedRoutes) {
-    panelRef.current.classList.remove('maximized');
+    panelRef.current?.classList.remove('maximized');
     resetClickedStates(null, clickedFeatureRef, updateClickedFeature);
     return;
   }


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6431

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev. 
2. Create a route that passes through an Advisory.
3. On the Routes panel, click "View Details".
4. Click the Advisory item on Route details. The sidepanel for the advisory opens.
5. Click "Share" and copy the link.
6. Open the link in a new browser.
7. Verify the receiver of the shared link sees the advisory within the route as if they created the route and then drilled down into Route details and clicked the Advisory themselves.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented