### PR TITLE
DBC22-6666: Fix leader election script bug

### DIFF
--- a/compose/backend/leader-election.py
+++ b/compose/backend/leader-election.py
@@ -106,7 +106,8 @@ def _is_expired(lease) -> bool:
     if renew_time is None:
         return True
     if isinstance(renew_time, str):
-        renew_dt = datetime.strptime(renew_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        ts = renew_time.replace('Z', '+00:00')
+        renew_dt = datetime.fromisoformat(ts)
     else:
         renew_dt = renew_time  # already a datetime
     age = (datetime.now(timezone.utc) - renew_dt).total_seconds()
@@ -197,9 +198,15 @@ def main():
                     _stop_huey()
                     leading = False
                 else:
-                    # Check Huey is still up; if it died, exit so the pod restarts
-                    if not _huey_alive():
-                        logger.error("Huey exited unexpectedly — terminating pod so it restarts")
+                    if huey_process is None:
+                        # We hold the lease (e.g. after a container restart) 
+                        # but haven't started the process yet.
+                        logger.info("Already hold lease after restart — starting Huey")
+                        leading = True
+                        _start_huey()
+                    elif not _huey_alive():
+                        # Huey was running, but now it's not.
+                        logger.error("Huey exited unexpectedly — terminating container so it restarts")
                         os._exit(1)
 
             elif _is_expired(lease):


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6666

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? NO
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Open the tasks pod terminal
2. Run `pkill -f run_huey`
3. It should terminate and then restart the service on it's own after the container restart
4. Also try kill the pod itself and ensure that a new pod starts huey
5. Try scale up Tasks pod and ensure only 1 is actually running huey

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented