### PR TITLE
DBC22-6539: update timestamps when image ingested in only to void timestamps inconsistency

### DIFF
--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -83,19 +83,6 @@ def populate_webcam_from_data(webcam_data):
         return    
 
 
-def update_webcam_db_stale_delayed(camera: Webcam):
-    time_now_utc = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S%f")[:-3]
-    get_recent_timestamps(camera.id)  # Ensure timestamp_list is populated with latest data
-    camera_status = calculate_camera_status(camera.id, time_now_utc)
-    ts_seconds = int(camera_status["timestamp"])
-    dt_utc = datetime.datetime.fromtimestamp(ts_seconds, tz=ZoneInfo("UTC"))
-
-    Webcam.objects.filter(id=camera.id).update(
-        marked_stale=camera_status["stale"],
-        marked_delayed=camera_status["delayed"],
-        last_update_attempt=dt_utc,
-        last_update_modified=dt_utc),
-
 def update_cam_from_sql_db(id: int, current_time: datetime.datetime):
     try:
         cam = (
@@ -163,7 +150,6 @@ def format_region_name(region_name):
     return ''.join(result)
 
 def update_webcam_db(cam_id: int, cam_data: dict):
-    is_updated = False
     time_now_utc = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S%f")[:-3]
     camera_status = calculate_camera_status(cam_id, time_now_utc)
     ts_seconds = int(camera_status["timestamp"])
@@ -171,32 +157,39 @@ def update_webcam_db(cam_id: int, cam_data: dict):
 
     existing_webcam = Webcam.objects.filter(id=cam_id).first()
     if not existing_webcam:
-        return is_updated
-    else:
-        for field in CAMERA_DIFF_FIELDS:
-            source_field = CAMERA_FIELD_MAPPING.get(field, field)
-            webcam_value = getattr(existing_webcam, field)
-            if field in ['marked_stale', 'marked_delayed']:
-                source_value = camera_status[source_field]
-            else:
-                source_value = cam_data.get(source_field)
-            if webcam_value != source_value:
-                Webcam.objects.filter(id=cam_id).update(
-                    is_on=True if cam_data.get("isOn") == 1 else False,
-                    should_appear=True if cam_data.get("should_appear") == 1 else False,
-                    name=cam_data.get("cam_internetname"),
-                    caption=cam_data.get("cam_internetcaption"),
-                    is_new=cam_data.get("isNew"),
-                    is_on_demand=cam_data.get("isOnDemand"),
-                    last_update_attempt=dt_utc,
-                    last_update_modified=dt_utc,
-                    update_period_mean=camera_status["mean_interval"],
-                    update_period_stddev=camera_status["stddev_interval"],
-                    marked_stale=camera_status["stale"],
-                    marked_delayed=camera_status["delayed"],
-                )
-                is_updated = True
-        return is_updated
+        return False
+
+    should_update = False
+    for field in CAMERA_DIFF_FIELDS:
+        source_field = CAMERA_FIELD_MAPPING.get(field, field)
+        webcam_value = getattr(existing_webcam, field)
+        if field in ['marked_stale', 'marked_delayed']:
+            source_value = camera_status[source_field]
+        else:
+            source_value = cam_data.get(source_field)
+
+        if webcam_value != source_value:
+            should_update = True
+            break
+
+    if not should_update:
+        return False
+
+    update_data = {
+        "is_on": True if cam_data.get("isOn") == 1 else False,
+        "should_appear": True if cam_data.get("should_appear") == 1 else False,
+        "name": cam_data.get("cam_internetname"),
+        "caption": cam_data.get("cam_internetcaption"),
+        "is_new": cam_data.get("isNew"),
+        "is_on_demand": cam_data.get("isOnDemand"),
+        "update_period_mean": camera_status["mean_interval"],
+        "update_period_stddev": camera_status["stddev_interval"],
+        "marked_stale": camera_status["stale"],
+        "marked_delayed": camera_status["delayed"],
+    }
+
+    Webcam.objects.filter(id=cam_id).update(**update_data)
+    return True
 
 def create_webcam_db(cam_data: dict):
     cam_id = cam_data.id

--- a/src/backend/apps/webcam/tests/test_webcam_populate.py
+++ b/src/backend/apps/webcam/tests/test_webcam_populate.py
@@ -11,7 +11,6 @@ from django.contrib.gis.geos import Point
 from apps.webcam.tests.test_webcam_ordering import side_effect_populate
 from django.core.exceptions import ObjectDoesNotExist
 from apps.webcam.tasks import populate_webcam_from_data
-from apps.webcam.tasks import update_webcam_db_stale_delayed, update_cam_from_sql_db
 
 # suppress logged error messages to reduce noise
 logging.getLogger().setLevel(logging.CRITICAL)
@@ -148,21 +147,3 @@ class TestWebcamModel(BaseTest):
 
             mock_logger.error.assert_called_once()
 
-    @patch("apps.webcam.tasks.populate_all_webcam_data")
-    def test_update_webcam_db_stale_delayed(self, mock_populate):
-        mock_populate.side_effect = lambda *args, **kwargs: side_effect_populate(self.mock_webcam_feed_result_2)
-        from apps.webcam import tasks
-        tasks.populate_all_webcam_data()
-
-        # Call the function
-        webcam = Webcam.objects.first()
-        update_webcam_db_stale_delayed(webcam)
-
-        # Refresh from DB
-        webcam.refresh_from_db()
-
-        # Assertions
-        self.assertFalse(webcam.marked_stale)
-        self.assertFalse(webcam.marked_delayed)
-        self.assertIsInstance(webcam.last_update_attempt, datetime.datetime)
-        self.assertIsInstance(webcam.last_update_modified, datetime.datetime)

--- a/src/backend/apps/webcam/tests/test_webcam_update_from_db.py
+++ b/src/backend/apps/webcam/tests/test_webcam_update_from_db.py
@@ -113,6 +113,41 @@ class TestUpdateWebcamDb(TestCase):
         result = update_webcam_db(cam_id=1, cam_data=camera_source_data)
         self.assertEqual(result, False)
 
+    @patch("apps.webcam.tasks.populate_all_webcam_data")
+    @patch("apps.webcam.tasks.calculate_camera_status")
+    def test_webcam_stale_or_delayed_does_not_update_timestamps(self, mock_calc_status, mock_populate):
+        _make_existing_webcam(mock_populate, mock_webcam_feed_result_1)
+        webcam = Webcam.objects.filter(id=1).first()
+
+        original_attempt = webcam.last_update_attempt
+        original_modified = webcam.last_update_modified
+
+        mock_calc_status.return_value = {
+            "timestamp": "1776852000",
+            "mean_interval": 10,
+            "stddev_interval": 2,
+            "stale": True,
+            "delayed": False,
+        }
+
+        camera_source_data = {
+            "id": 1,
+            "cam_internetname": "Test Cam",
+            "cam_internetcaption": "Updated Caption",
+            "isOn": True,
+            "should_appear": True,
+            "isNew": 0,
+            "isOnDemand": 0,
+        }
+
+        result = update_webcam_db(cam_id=1, cam_data=camera_source_data)
+        webcam.refresh_from_db()
+
+        self.assertTrue(result)
+        self.assertEqual(webcam.caption, "Updated Caption")
+        self.assertEqual(webcam.last_update_attempt, original_attempt)
+        self.assertEqual(webcam.last_update_modified, original_modified)
+
 class TestCreateWebcamDb(TestCase):
 
     @patch("apps.webcam.tasks.populate_all_webcam_data")


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6539

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev.
2. Go to webcam monitor https://nginx-html-host-route-a781ec-tools.apps.golddr.devops.gov.bc.ca/staledelayed.html to pick one stale/delayed cam, i.e., pick cam 494.
3. Verify response values of last_update_attempt, and last_update_modified returned from https://dev.drivebc.ca/api/webcams/494/ and https://drivebc.ca/api/webcams/494/ are the same.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented