### PR TITLE
DBC22-5326: deselect map feature when reversing route on mobile

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -1021,6 +1021,13 @@ export default function DriveBCMap(props) {
     }
   }, [filteredAdvisories]);
 
+  // DBC22-5326: clear selected feature when route swap clears reference params
+  useEffect(() => {
+    if (!referenceData?.type && clickedFeatureRef.current) {
+      resetClickedStates(null, clickedFeatureRef, updateClickedFeature);
+    }
+  }, [referenceData?.type]);
+
   // Reset search params when panel is closed
   useEffect(() => {
     if (searchParamInitialized.current) {

--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -1025,6 +1025,7 @@ export default function DriveBCMap(props) {
   useEffect(() => {
     if (!referenceData?.type && clickedFeatureRef.current) {
       resetClickedStates(null, clickedFeatureRef, updateClickedFeature);
+      dispatch(updateShowRouteObjs(false));
     }
   }, [referenceData?.type]);
 

--- a/src/frontend/src/Components/routing/RouteSearch.js
+++ b/src/frontend/src/Components/routing/RouteSearch.js
@@ -161,6 +161,10 @@ const RouteSearch = forwardRef((props, ref) => {
 
   // Handlers
   const swapHandler = () => {
+    if (resetClickedStates) {
+      resetClickedStates();
+    }
+
     searchParams.delete('type');
     searchParams.delete('id');
     searchParams.delete('display_category');

--- a/src/frontend/src/Components/routing/RouteSearch.js
+++ b/src/frontend/src/Components/routing/RouteSearch.js
@@ -163,6 +163,7 @@ const RouteSearch = forwardRef((props, ref) => {
   const swapHandler = () => {
     if (resetClickedStates) {
       resetClickedStates();
+      dispatch(updateShowRouteObjs(false));
     }
 
     searchParams.delete('type');


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-5326

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. On a mobile browser, open the Map and create a route.
2. Enable the cameras layer and tap a camera icon along the route.
3. Reverse the route using the swap button.
4. Verify the selected item panel closes and the map icon is deselected while the new route loads.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented