### PR TITLE
DBC22-6169: Fixed long delays and blank image showing when turning on/off cameras

### DIFF
--- a/compose/backend/Dockerfile.dev
+++ b/compose/backend/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies for SQL database connection
-# msodbcsql17 is amd64-only; msodbcsql18 supports arm64 on Debian 12+
+# msodbcsql18 is amd64-only; msodbcsql18 supports arm64 on Debian 12+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl gnupg2 apt-transport-https && \
     curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg && \

--- a/compose/backend/leader-election.py
+++ b/compose/backend/leader-election.py
@@ -50,7 +50,6 @@ RETRY_INTERVAL = int(os.environ.get("RETRY_INTERVAL", "3"))
 
 huey_process: subprocess.Popen | None = None
 
-monitor_process = None
 
 # ---------------------------------------------------------------------------
 # Lease helpers

--- a/compose/backend/leader-election.py
+++ b/compose/backend/leader-election.py
@@ -50,6 +50,8 @@ RETRY_INTERVAL = int(os.environ.get("RETRY_INTERVAL", "3"))
 
 huey_process: subprocess.Popen | None = None
 
+monitor_process = None
+
 # ---------------------------------------------------------------------------
 # Lease helpers
 # ---------------------------------------------------------------------------
@@ -202,7 +204,7 @@ def main():
                         # We hold the lease (e.g. after a container restart) 
                         # but haven't started the process yet.
                         logger.info("Already hold lease after restart — starting Huey")
-                        leading = True
+                        leading = True 
                         _start_huey()
                     elif not _huey_alive():
                         # Huey was running, but now it's not.

--- a/src/backend/apps/consumer/processor.py
+++ b/src/backend/apps/consumer/processor.py
@@ -27,6 +27,11 @@ from apps.shared.status import get_recent_timestamps, calculate_camera_status
 from botocore.config import Config
 from django.contrib.gis.geos import Point
 from django.db import close_old_connections, connection
+from apps.webcam.enums import (
+    CAMERA_DIFF_FIELDS,
+    CAMERA_FIELD_MAPPING,
+)
+from asgiref.sync import sync_to_async
 
 
 tf = TimezoneFinder()
@@ -463,21 +468,31 @@ def save_watermarked_image_to_pvc(camera_id: str, image_bytes: bytes, timestamp:
     except Exception as e:
         logging.exception(f"Error saving image to PVC {filepath}: {e}")
 
-def save_watermarked_image_to_drivebc_pvc(camera_id: str, image_bytes: bytes, is_on: bool):  
-    os.makedirs(os.path.dirname(f'{DRIVEBC_PVC_WATERMARKED_PATH}'), exist_ok=True)
+def check_backup_exists(camera_id: str) -> bool:
+    backup_dir = os.path.join(DRIVEBC_PVC_WATERMARKED_PATH, "backup")
+    backup_filepath = os.path.join(backup_dir, f"{camera_id}.jpg")
+    return os.path.exists(backup_filepath)
 
-    save_dir = os.path.join(DRIVEBC_PVC_WATERMARKED_PATH)
+def save_watermarked_image_to_drivebc_pvc(camera_id: str, image_bytes: bytes, is_on: bool):
+    save_dir = DRIVEBC_PVC_WATERMARKED_PATH
+    backup_dir = os.path.join(save_dir, "backup")
+
     os.makedirs(save_dir, exist_ok=True)
+    os.makedirs(backup_dir, exist_ok=True)
+
     filename = f"{camera_id}.jpg"
     filepath = os.path.join(save_dir, filename)
 
     try:
+        # Save the new image
         with open(filepath, "wb") as f:
             f.write(image_bytes)
+
         if is_on:
-            logger.info(f"Watermarked image saved to drivebc PVC at {filepath}")
+            logger.info(f"Watermarked image saved to DriveBC PVC at {filepath}")
+
     except Exception as e:
-        logging.exception(f"Error saving image to drivebc PVC {filepath}: {e}")
+        logging.exception(f"Error saving image to DriveBC PVC {filepath}: {e}")
 
 def delete_watermarked_image_from_pvc(camera_id: str):
     save_dir = os.path.join(PVC_WATERMARKED_PATH, camera_id)
@@ -731,6 +746,28 @@ async def handle_image_message(camera_id: str, body: bytes, timestamp: str, came
         save_watermarked_image_to_drivebc_pvc(camera_id, blank_out_image_bytes, webcam.get('is_on'))
         # Save watermarked images to S3 with timestamp
         push_to_s3(watermarked_image_bytes, camera_id, False, utc_timestamp_str)
+
+    existing_webcam = await sync_to_async(
+        Webcam.objects.filter(id=camera_id).first
+    )()
+    if not existing_webcam:
+        return
+    
+    should_update = False
+    for field in CAMERA_DIFF_FIELDS:
+        source_field = CAMERA_FIELD_MAPPING.get(field, field)
+        webcam_value = getattr(existing_webcam, field)
+        if field in ['marked_stale', 'marked_delayed', 'update_period_mean', 'update_period_stddev']:
+            source_value = camera_status[source_field]
+        else:
+            source_value = webcam.get(source_field)
+    
+        if webcam_value != source_value:
+            should_update = True
+            break
+    
+    if not should_update:
+            return
 
     await update_webcam(
             camera_id,

--- a/src/backend/apps/consumer/processor.py
+++ b/src/backend/apps/consumer/processor.py
@@ -468,10 +468,6 @@ def save_watermarked_image_to_pvc(camera_id: str, image_bytes: bytes, timestamp:
     except Exception as e:
         logging.exception(f"Error saving image to PVC {filepath}: {e}")
 
-def check_backup_exists(camera_id: str) -> bool:
-    backup_dir = os.path.join(DRIVEBC_PVC_WATERMARKED_PATH, "backup")
-    backup_filepath = os.path.join(backup_dir, f"{camera_id}.jpg")
-    return os.path.exists(backup_filepath)
 
 def save_watermarked_image_to_drivebc_pvc(camera_id: str, image_bytes: bytes, is_on: bool):
     save_dir = DRIVEBC_PVC_WATERMARKED_PATH

--- a/src/backend/apps/consumer/tasks.py
+++ b/src/backend/apps/consumer/tasks.py
@@ -1,6 +1,6 @@
 import logging
 import io
-from apps.consumer.processor import check_backup_exists, process_camera_rows, blank_out_image, save_watermarked_image_to_drivebc_pvc, delete_watermarked_image_from_pvc, delete_offline_webcam_records
+from apps.consumer.processor import process_camera_rows, blank_out_image, save_watermarked_image_to_drivebc_pvc, delete_watermarked_image_from_pvc, delete_offline_webcam_records
 from datetime import datetime
 from apps.webcam.models import Webcam
 from .db import get_all_from_db
@@ -37,6 +37,4 @@ def generate_offline_camera_images():
                 delete_watermarked_image_from_pvc(camera_id)
                 # Delete all the records from image index table for offline cams
                 async_to_sync(delete_offline_webcam_records)(camera_id)
-                if not check_backup_exists(camera_id):
-                    # Save blank image for current image displaying
-                    save_watermarked_image_to_drivebc_pvc(camera_id, watermarked, False)
+                save_watermarked_image_to_drivebc_pvc(camera_id, watermarked, False)

--- a/src/backend/apps/consumer/tasks.py
+++ b/src/backend/apps/consumer/tasks.py
@@ -1,15 +1,10 @@
 import logging
 import io
-
-from apps.consumer.processor import process_camera_rows, watermark, blank_out_image, save_watermarked_image_to_pvc, save_watermarked_image_to_drivebc_pvc, delete_watermarked_image_from_pvc, delete_offline_webcam_records
+from apps.consumer.processor import check_backup_exists, process_camera_rows, blank_out_image, save_watermarked_image_to_drivebc_pvc, delete_watermarked_image_from_pvc, delete_offline_webcam_records
 from datetime import datetime
-
 from apps.webcam.models import Webcam
 from .db import get_all_from_db
-import pytz
 from PIL import Image
-import pprint
-
 from asgiref.sync import async_to_sync
 
 logger = logging.getLogger(__name__)
@@ -23,6 +18,10 @@ def generate_offline_camera_images():
     timestamp = now.strftime("%Y%m%d%H%M%S%f")
     
     for camera in cameras:
+        exists = Webcam.objects.filter(id=camera["id"]).exists()
+        if not exists:
+            continue
+
         if not camera.get('is_on', True):
             camera_id = str(camera['id'])
             tz = 'America/Vancouver'
@@ -38,10 +37,6 @@ def generate_offline_camera_images():
                 delete_watermarked_image_from_pvc(camera_id)
                 # Delete all the records from image index table for offline cams
                 async_to_sync(delete_offline_webcam_records)(camera_id)
-                # Save blank image for current image displaying
-                save_watermarked_image_to_drivebc_pvc(camera_id, watermarked, False)
-            # Update postgres db is_on status to False for offline cameras
-            Webcam.objects.filter(id=camera['id']).update(is_on=False)
-        else:
-            # Update postgres db is_on status to True for online cameras
-            Webcam.objects.filter(id=camera['id']).update(is_on=True)
+                if not check_backup_exists(camera_id):
+                    # Save blank image for current image displaying
+                    save_watermarked_image_to_drivebc_pvc(camera_id, watermarked, False)

--- a/src/backend/apps/consumer/tests/test_processor.py
+++ b/src/backend/apps/consumer/tests/test_processor.py
@@ -1021,36 +1021,6 @@ class TestSaveDriveBCImage(TestCase):
 
         mock_file().write.assert_called_once_with(b"image")
 
-
-    @patch(
-        "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
-        "/tmp/drivebc"
-    )
-    @patch("apps.consumer.processor.os.path.exists")
-    @patch("apps.consumer.processor.shutil.move")
-    @patch("apps.consumer.processor.open", new_callable=mock_open)
-    @patch("apps.consumer.processor.os.makedirs")
-    def test_save_drivebc_skip_backup_if_exists(
-        self,
-        mock_makedirs,
-        mock_file,
-        mock_move,
-        mock_exists,
-    ):
-
-        mock_exists.side_effect = [
-            True,
-            True,
-        ]
-
-        save_watermarked_image_to_drivebc_pvc(
-            "123",
-            b"blank",
-            False,
-        )
-
-        mock_move.assert_not_called()
-
 class TestDeleteWatermarkedImage(TestCase):
 
     @patch(

--- a/src/backend/apps/consumer/tests/test_processor.py
+++ b/src/backend/apps/consumer/tests/test_processor.py
@@ -1,16 +1,25 @@
 import os
-from unittest.mock import patch, MagicMock, AsyncMock
+from PIL import Image
+from unittest.mock import patch, MagicMock, AsyncMock, mock_open
 from datetime import datetime
 import io
 
+from aiormq import AMQPConnectionError
 from django.test import TestCase
 from django.core.cache import cache
 import asyncio
 
 
 from apps.consumer.processor import (
+    PVC_ORIGINAL_PATH,
+    blank_out_image,
+    consume_from,
+    consume_queue,
     process_camera_rows,
     get_timezone,
+    process_message,
+    safe_db_call,
+    save_original_image_to_pvc,
     watermark,
     verify_image,
     push_to_s3,
@@ -20,13 +29,23 @@ from apps.consumer.processor import (
 from apps.webcam.models import Webcam
 from apps.consumer import processor
 
+from apps.consumer.processor import (
+    save_watermarked_image_to_pvc,
+    save_watermarked_image_to_drivebc_pvc,
+    delete_watermarked_image_from_pvc,
+    generate_local_timestamp,
+    update_webcam,
+    handle_image_message,
+)
+
+def reset_stop_event():
+    processor.stop_event = asyncio.Event()
 
 class MockCameraRow:
     """Mock camera row object for testing process_camera_rows"""
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
-
 
 class TestProcessCameraRows(TestCase):
     def test_process_camera_rows_with_valid_data(self):
@@ -96,7 +115,6 @@ class TestProcessCameraRows(TestCase):
         result = process_camera_rows([])
         self.assertEqual(result, [])
 
-
 class TestGetTimezone(TestCase):
     @patch('apps.consumer.processor.tf')
     def test_get_timezone_valid_coordinates(self, mock_tf):
@@ -122,6 +140,15 @@ class TestGetTimezone(TestCase):
 
         self.assertEqual(result, 'America/Vancouver')
 
+    def test_get_timezone_returns_default_when_coordinates_are_invalid(self):
+        webcam = {
+            "cam_locations_geo_latitude": "invalid",
+            "cam_locations_geo_longitude": "-123.3656",
+        }
+
+        result = get_timezone(webcam)
+
+        self.assertEqual(result, 'America/Vancouver')
 
 class TestWatermark(TestCase):
     def test_watermark_with_none_image_data(self):
@@ -130,7 +157,6 @@ class TestWatermark(TestCase):
         result = watermark(webcam, None, 'America/Vancouver', '20260309120000000')
 
         self.assertIsNone(result)
-
 
 class TestVerifyImage(TestCase):
     def test_verify_image_valid_jpeg(self):
@@ -152,7 +178,6 @@ class TestVerifyImage(TestCase):
 
         self.assertFalse(result)
 
-
 class TestIsCameraPushedTooSoon(TestCase):
     @patch('apps.consumer.processor.ImageIndex')
     def test_returns_false_when_no_previous_image(self, mock_image_index):
@@ -166,7 +191,6 @@ class TestIsCameraPushedTooSoon(TestCase):
         result = asyncio.run(run_test())
 
         self.assertFalse(result)
-
 
 class TestRefreshCameraCache(TestCase):
     def setUp(self):
@@ -481,6 +505,35 @@ class TestRabbitMQConsumer(TestCase):
 
         self.assertTrue(stop_event.is_set())
 
+    @patch("apps.consumer.processor.logger")
+    @patch("apps.consumer.processor.process_message", new_callable=AsyncMock)
+    async def test_consume_queue_stop_event_breaks_loop(
+        self,
+        mock_process_message,
+        mock_logger,
+    ):
+        message = MagicMock()
+
+        # Mock the async context manager returned by queue.iterator()
+        queue_iter = AsyncMock()
+        queue_iter.__aiter__.return_value = [message]
+
+        queue = MagicMock()
+        queue.iterator.return_value.__aenter__.return_value = queue_iter
+        queue.iterator.return_value.__aexit__.return_value = None
+
+        with patch(
+            "apps.consumer.processor.stop_event.is_set",
+            return_value=True,
+        ):
+            await consume_queue(queue, "GOLD")
+
+        mock_logger.info.assert_called_once_with(
+            "Stop requested. Breaking consume loop for GOLD."
+        )
+
+        mock_process_message.assert_not_called()
+
 class TestParseRows(TestCase):
 
     @patch("apps.consumer.processor.process_camera_rows")
@@ -536,8 +589,802 @@ class TestParseRows(TestCase):
 
         mock_logger.info.assert_called()
 
-def reset_stop_event():
-    import asyncio
-    from apps.consumer import processor
+class TestProcessMessage(TestCase):
 
-    processor.stop_event = asyncio.Event()
+    @patch("apps.consumer.processor.logger")
+    @patch("apps.consumer.processor.handle_image_message", new_callable=AsyncMock)
+    @patch("apps.consumer.processor.safe_db_call")
+    @patch("apps.consumer.processor.generate_local_timestamp")
+    @patch("apps.consumer.processor.calculate_camera_status")
+    @patch("apps.consumer.processor.sync_to_async")
+    async def test_process_message_success(
+        self,
+        mock_sync_to_async,
+        mock_calculate_status,
+        mock_generate_local_timestamp,
+        mock_safe_db_call,
+        mock_handle_image,
+        mock_logger,
+    ):
+        message = MagicMock()
+        message.headers = {
+            "filename": "12345_20250101.jpg",
+            "timestamp": "2025-01-01T00:00:00Z",
+        }
+        message.body = b"image"
+
+        process_cm = AsyncMock()
+        message.process.return_value = process_cm
+
+        def sync_wrapper(func):
+            if func == mock_calculate_status:
+                return AsyncMock(return_value=True)
+            return AsyncMock(return_value="local_timestamp")
+
+        mock_sync_to_async.side_effect = sync_wrapper
+
+        await process_message(message)
+
+        mock_handle_image.assert_awaited_once_with(
+            "12345",
+            b"image",
+            "local_timestamp",
+            True,
+        )
+
+        mock_logger.info.assert_called_once_with(
+            "Processed message for camera %s.",
+            "12345",
+        )
+
+    @patch("apps.consumer.processor.logger")
+    @patch(
+        "apps.consumer.processor.handle_image_message",
+        new_callable=AsyncMock,
+        side_effect=asyncio.TimeoutError,
+    )
+    @patch("apps.consumer.processor.sync_to_async")
+    async def test_process_message_timeout(
+        self,
+        mock_sync_to_async,
+        mock_handle_image,
+        mock_logger,
+    ):
+        message = MagicMock()
+        message.headers = {
+            "filename": "123.jpg",
+            "timestamp": "2025",
+        }
+        message.body = b""
+
+        message.process.return_value = AsyncMock()
+
+        mock_sync_to_async.side_effect = [
+            AsyncMock(return_value=True),
+            AsyncMock(return_value="local"),
+        ]
+
+        await process_message(message)
+
+        mock_logger.error.assert_called_once_with(
+            "Processing timeout for camera 123"
+        )
+
+class TestWatermark(TestCase):
+
+    def create_image(self, width=640, height=480):
+        img = Image.new("RGB", (width, height), color="red")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        return buf.getvalue()
+    
+    def test_returns_none_when_image_is_none(self):
+        webcam = {"dbc_mark": "TEST"}
+
+        result = watermark(
+            webcam,
+            None,
+            "America/Vancouver",
+            "20250720120000000000",
+        )
+
+        self.assertIsNone(result)
+
+    def test_successfully_watermarks_image(self):
+        webcam = {"dbc_mark": "DriveBC"}
+
+        result = watermark(
+            webcam,
+            self.create_image(),
+            "America/Vancouver",
+            "20250720120000000000",
+        )
+
+        self.assertIsNotNone(result)
+
+        img = Image.open(io.BytesIO(result))
+
+        # original height = 480
+        self.assertEqual(img.size, (640, 498))
+
+    def test_missing_dbc_mark(self):
+        webcam = {}
+
+        result = watermark(
+            webcam,
+            self.create_image(),
+            "America/Vancouver",
+            "20250720120000000000",
+        )
+
+        self.assertIsNotNone(result)
+
+    def test_invalid_timestamp_returns_none(self):
+        webcam = {"dbc_mark": "DriveBC"}
+
+        result = watermark(
+            webcam,
+            self.create_image(),
+            "America/Vancouver",
+            "bad timestamp",
+        )
+
+        self.assertIsNone(result)
+
+    def test_invalid_image_returns_none(self):
+        webcam = {"dbc_mark": "DriveBC"}
+
+        result = watermark(
+            webcam,
+            b"not an image",
+            "America/Vancouver",
+            "20250720120000000000",
+        )
+
+        self.assertIsNone(result)
+
+    def test_watermark_resizes_large_image(self):
+        # Create a large image (width > 800)
+        original_width = 1600
+        original_height = 1000
+
+        image = Image.new(
+            "RGB",
+            (original_width, original_height),
+            color="black",
+        )
+
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG")
+
+        webcam = {
+            "dbc_mark": "DriveBC",
+        }
+
+        result = watermark(
+            webcam=webcam,
+            image_data=buffer.getvalue(),
+            tz="America/Vancouver",
+            timestamp="202607290900000000",
+        )
+
+        assert result is not None
+        assert isinstance(result, bytes)
+
+        # Verify the output image dimensions
+        output = Image.open(io.BytesIO(result))
+
+        # Expected:
+        # width = 800
+        # height = floor(1000 * 800 / 1600) + 18 black bar
+        assert output.width == 800
+        assert output.height == 518
+
+class TestSaveImage(TestCase):
+
+    def test_blank_out_image_returns_none_when_image_data_is_none(self):
+        webcam = {
+            "name": "Test Camera Offline",
+            "dbc_mark": "DriveBC",
+        }
+
+        result = blank_out_image(
+            webcam=webcam,
+            image_data=None,
+            tz="America/Vancouver",
+            timestamp="20260729090000",
+        )
+
+        assert result is None
+
+    def test_blank_out_image_success(self):
+        image = Image.new("RGB", (720, 480), color="black")
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG")
+
+        webcam = {
+            "name": "Test Camera Offline",
+            "dbc_mark": "DriveBC",
+        }
+
+        result = blank_out_image(
+            webcam=webcam,
+            image_data=buffer.getvalue(),
+            tz="America/Vancouver",
+            timestamp="20260729090000",
+        )
+
+        assert result is not None
+        assert isinstance(result, bytes)
+
+        generated = Image.open(io.BytesIO(result))
+        assert generated.size == (720, 498)
+
+    def test_blank_out_image_resizes_large_image(self):
+        image = Image.new("RGB", (1600, 1000), color="black")
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG")
+
+        webcam = {
+            "name": "Test Camera Offline",
+            "dbc_mark": "DriveBC",
+        }
+
+        result = blank_out_image(
+            webcam=webcam,
+            image_data=buffer.getvalue(),
+            tz="America/Vancouver",
+            timestamp="20260729090000",
+        )
+
+        generated = Image.open(io.BytesIO(result))
+
+        assert generated.width == 800
+        assert generated.height == 518      # floor(1000 * 800 / 1600) + 18
+
+    def test_blank_out_image_with_no_message(self):
+        image = Image.new("RGB", (720, 480), color="black")
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG")
+
+        webcam = {
+            "dbc_mark": "DriveBC",
+        }
+
+        result = blank_out_image(
+            webcam=webcam,
+            image_data=buffer.getvalue(),
+            tz="America/Vancouver",
+            timestamp="20260729090000",
+        )
+
+        assert result is not None
+
+    @patch("apps.consumer.processor.logging.exception")
+    @patch("apps.consumer.processor.Image.open")
+    def test_blank_out_image_logs_exception(self, mock_open, mock_logging):
+        mock_open.side_effect = Exception("Image error")
+
+        webcam = {
+            "name": "Test Camera Offline",
+            "dbc_mark": "DriveBC",
+        }
+
+        result = blank_out_image(
+            webcam=webcam,
+            image_data=b"invalid image",
+            tz="America/Vancouver",
+            timestamp="20260729090000",
+        )
+
+        assert result is None
+        mock_logging.assert_called_once()
+
+    @patch("apps.consumer.processor.PVC_ORIGINAL_PATH", "/app/images/webcams/originals")
+    @patch("apps.consumer.processor.open", new_callable=mock_open)
+    @patch("apps.consumer.processor.os.makedirs")
+    def test_save_original_image_to_pvc_success(
+        self,
+        mock_makedirs,
+        mock_file,
+    ):
+        camera_id = "123"
+        image_bytes = b"test image data"
+
+        save_original_image_to_pvc(
+            camera_id,
+            image_bytes,
+        )
+
+        mock_makedirs.assert_called_once_with(
+            "/app/images/webcams/originals",
+            exist_ok=True,
+        )
+
+        mock_file.assert_called_once_with(
+            "/app/images/webcams/originals/123.jpg",
+            "wb",
+        )
+
+        mock_file().write.assert_called_once_with(image_bytes)
+        
+class TestDbCall(TestCase):
+
+    @patch("apps.consumer.processor.connection")
+    @patch("apps.consumer.processor.close_old_connections")
+    def test_safe_db_call_success(
+        self,
+        mock_close_old_connections,
+        mock_connection,
+    ):
+        mock_func = MagicMock(return_value="success")
+
+        result = safe_db_call(mock_func, 1, 2, key="value")
+
+        self.assertEqual(result, "success")
+        mock_close_old_connections.assert_called_once()
+        mock_connection.ensure_connection.assert_called_once()
+        mock_func.assert_called_once_with(1, 2, key="value")
+
+    @patch("apps.consumer.processor.connection")
+    @patch("apps.consumer.processor.close_old_connections")
+    def test_safe_db_call_propagates_exception(
+        self,
+        mock_close_old_connections,
+        mock_connection,
+    ):
+        mock_func = MagicMock(side_effect=RuntimeError("DB error"))
+
+        with self.assertRaises(RuntimeError):
+            safe_db_call(mock_func)
+
+        mock_close_old_connections.assert_called_once()
+        mock_connection.ensure_connection.assert_called_once()
+        mock_func.assert_called_once_with()
+
+class TestSaveWatermarkedImageToPVC(TestCase):
+
+    @patch("apps.consumer.processor.PVC_WATERMARKED_PATH", "/tmp/watermarked")
+    @patch("apps.consumer.processor.open", new_callable=mock_open)
+    @patch("apps.consumer.processor.os.makedirs")
+    def test_save_watermarked_image_success(
+        self,
+        mock_makedirs,
+        mock_file,
+    ):
+        save_watermarked_image_to_pvc(
+            "123",
+            b"image",
+            "20260729090000",
+            True,
+        )
+
+        self.assertTrue(mock_makedirs.called)
+
+        mock_file.assert_called_once_with(
+            "/tmp/watermarked/123/20260729090000.jpg",
+            "wb",
+        )
+
+        mock_file().write.assert_called_once_with(b"image")
+
+
+    @patch("apps.consumer.processor.logging.exception")
+    @patch("apps.consumer.processor.open")
+    @patch("apps.consumer.processor.os.makedirs")
+    @patch("apps.consumer.processor.PVC_WATERMARKED_PATH", "/tmp")
+    def test_save_watermarked_image_exception(
+        self,
+        mock_makedirs,
+        mock_open_file,
+        mock_logging,
+    ):
+        mock_open_file.side_effect = Exception("disk full")
+
+        save_watermarked_image_to_pvc(
+            "123",
+            b"image",
+            "20260729090000",
+            True,
+        )
+
+        mock_logging.assert_called_once()
+
+class TestSaveDriveBCImage(TestCase):
+
+    @patch(
+        "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
+        "/tmp/drivebc"
+    )
+    @patch("apps.consumer.processor.open", new_callable=mock_open)
+    @patch("apps.consumer.processor.os.makedirs")
+    @patch("apps.consumer.processor.os.path.exists")
+    def test_save_drivebc_image_online(
+        self,
+        mock_exists,
+        mock_makedirs,
+        mock_file,
+    ):
+
+        mock_exists.return_value = False
+
+        save_watermarked_image_to_drivebc_pvc(
+            "123",
+            b"image",
+            True,
+        )
+
+        mock_file.assert_called_once_with(
+            "/tmp/drivebc/123.jpg",
+            "wb",
+        )
+
+        mock_file().write.assert_called_once_with(b"image")
+
+
+    @patch(
+        "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
+        "/tmp/drivebc"
+    )
+    @patch("apps.consumer.processor.os.path.exists")
+    @patch("apps.consumer.processor.shutil.move")
+    @patch("apps.consumer.processor.open", new_callable=mock_open)
+    @patch("apps.consumer.processor.os.makedirs")
+    def test_save_drivebc_skip_backup_if_exists(
+        self,
+        mock_makedirs,
+        mock_file,
+        mock_move,
+        mock_exists,
+    ):
+
+        mock_exists.side_effect = [
+            True,
+            True,
+        ]
+
+        save_watermarked_image_to_drivebc_pvc(
+            "123",
+            b"blank",
+            False,
+        )
+
+        mock_move.assert_not_called()
+
+class TestDeleteWatermarkedImage(TestCase):
+
+    @patch(
+        "apps.consumer.processor.PVC_WATERMARKED_PATH",
+        "/tmp/watermarked"
+    )
+    @patch("apps.consumer.processor.os.remove")
+    @patch("apps.consumer.processor.os.listdir")
+    @patch("apps.consumer.processor.os.path.exists")
+    def test_delete_watermarked_images(
+        self,
+        mock_exists,
+        mock_listdir,
+        mock_remove,
+    ):
+
+        mock_exists.return_value = True
+        mock_listdir.return_value = [
+            "1.jpg",
+            "2.jpg",
+        ]
+
+        delete_watermarked_image_from_pvc("123")
+
+        self.assertEqual(
+            mock_remove.call_count,
+            0
+        )
+
+
+    @patch(
+        "apps.consumer.processor.PVC_WATERMARKED_PATH",
+        "/tmp/watermarked"
+    )
+    @patch("apps.consumer.processor.os.path.exists")
+    def test_delete_when_directory_missing(
+        self,
+        mock_exists,
+    ):
+
+        mock_exists.return_value = False
+
+        delete_watermarked_image_from_pvc("123")
+
+        mock_exists.assert_called_once()
+
+class TestPushToS3(TestCase):
+
+    @patch("apps.consumer.processor.requests.put")
+    @patch("apps.consumer.processor.s3_client.generate_presigned_url")
+    def test_push_to_s3_success(
+        self,
+        mock_url,
+        mock_put,
+    ):
+
+        mock_url.return_value = "http://s3/upload"
+
+        response = MagicMock()
+        response.status_code = 200
+        mock_put.return_value = response
+
+
+        push_to_s3(
+            b"image",
+            "123",
+            False,
+            "20260729090000",
+        )
+
+
+        mock_put.assert_called_once()
+
+
+    @patch("apps.consumer.processor.requests.put")
+    @patch("apps.consumer.processor.s3_client.generate_presigned_url")
+    def test_push_to_s3_failure(
+        self,
+        mock_url,
+        mock_put,
+    ):
+
+        mock_url.return_value = "url"
+
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "error"
+
+        mock_put.return_value = response
+
+
+        with self.assertRaises(RuntimeError):
+            push_to_s3(
+                b"image",
+                "123",
+                False,
+                "20260729090000",
+            )
+
+class TestHandleImageMessage(TestCase):
+
+    def setUp(self):
+        processor.db_data = [
+            {
+                "id": 123,
+                "is_on": True,
+                "cam_locations_geo_latitude": "49",
+                "cam_locations_geo_longitude": "-123",
+                "dbc_mark": "DriveBC",
+            }
+        ]
+
+    @patch("apps.consumer.processor.save_original_image_to_pvc")
+    @patch("apps.consumer.processor.update_webcam", new_callable=AsyncMock)
+    @patch("apps.consumer.processor.Webcam")
+    @patch("apps.consumer.processor.insert_image_index",
+           new_callable=AsyncMock)
+    @patch("apps.consumer.processor.push_to_s3")
+    @patch("apps.consumer.processor.save_watermarked_image_to_drivebc_pvc")
+    @patch("apps.consumer.processor.save_watermarked_image_to_pvc")
+    @patch("apps.consumer.processor.watermark")
+    @patch("apps.consumer.processor.verify_image")
+    @patch("apps.consumer.processor.is_camera_pushed_too_soon",
+           new_callable=AsyncMock)
+    async def test_handle_image_message_camera_online(
+        self,
+        mock_too_soon,
+        mock_verify,
+        mock_watermark,
+        mock_save_watermarked,
+        mock_save_drivebc,
+        mock_s3,
+        mock_insert,
+        mock_webcam,
+        mock_update_webcam,
+        save_original_image_to_pvc,
+    ):
+
+        mock_too_soon.return_value = False
+        mock_verify.return_value = True
+        mock_watermark.return_value = b"watermark"
+
+
+        fake_webcam = MagicMock()
+        fake_webcam.is_on = True
+
+        mock_webcam.objects.filter.return_value.first.return_value = fake_webcam
+
+
+        await handle_image_message(
+            "123",
+            b"image",
+            "202607290900000000",
+            {
+                "mean_interval": 10,
+                "stddev_interval": 5,
+                "stale": False,
+                "delayed": False,
+            }
+        )
+
+
+        mock_verify.assert_called_once()
+
+        mock_watermark.assert_called_once()
+
+        mock_save_watermarked.assert_called_once()
+
+        mock_save_drivebc.assert_called_once()
+
+        mock_insert.assert_called_once()
+
+    @patch("apps.consumer.processor.save_original_image_to_pvc")
+    @patch("apps.consumer.processor.update_webcam", new_callable=AsyncMock)
+    @patch("apps.consumer.processor.Webcam")
+    @patch("apps.consumer.processor.push_to_s3")
+    @patch("apps.consumer.processor.save_watermarked_image_to_drivebc_pvc")
+    @patch("apps.consumer.processor.blank_out_image")
+    @patch("apps.consumer.processor.verify_image")
+    @patch(
+        "apps.consumer.processor.is_camera_pushed_too_soon",
+        new_callable=AsyncMock,
+    )
+    async def test_handle_image_message_camera_offline(
+        self,
+        mock_too_soon,
+        mock_verify,
+        mock_blank,
+        mock_save_drivebc,
+        mock_s3,
+        mock_webcam,
+        mock_update_webcam,
+        mock_save_original_image,
+    ):
+
+        with patch.object(
+            processor,
+            "db_data",
+            [
+                {
+                    "id": 123,
+                    "is_on": False,
+                }
+            ],
+        ):
+            mock_too_soon.return_value = False
+            mock_verify.return_value = True
+            mock_blank.return_value = b"blank"
+
+            mock_webcam.objects.filter.return_value.first.return_value = MagicMock()
+
+            await handle_image_message(
+                "123",
+                b"image",
+                "202607290900000000",
+                {
+                    "mean_interval": 10,
+                    "stddev_interval": 5,
+                    "stale": False,
+                    "delayed": False,
+                },
+            )
+
+        mock_blank.assert_called_once()
+        mock_save_drivebc.assert_called_once()
+        mock_save_original_image.assert_called_once_with("123", b"image")
+        mock_update_webcam.assert_awaited_once()
+
+class TestGenerateLocalTimestamp(TestCase):
+
+    @patch("apps.consumer.processor.tf")
+    def test_generate_local_timestamp_success(
+        self,
+        mock_tf
+    ):
+
+        mock_tf.timezone_at.return_value = (
+            "America/Vancouver"
+        )
+
+        db_data = [
+            {
+                "id":1,
+                "cam_locations_geo_latitude":"49",
+                "cam_locations_geo_longitude":"-123",
+            }
+        ]
+
+        result = generate_local_timestamp(
+            db_data,
+            "1",
+            "202607290900000000"
+        )
+
+        self.assertIsNotNone(result)
+
+
+    def test_generate_local_timestamp_camera_missing(self):
+
+        result = generate_local_timestamp(
+            [],
+            "999",
+            "202607290900000000"
+        )
+
+        self.assertIsNotNone(result)
+
+class TestUpdateWebcam(TestCase):
+
+    @patch("apps.consumer.processor.calculate_camera_status")
+    @patch("apps.consumer.processor.Webcam")
+    @patch("apps.consumer.processor.RegionHighway")
+    @patch("apps.consumer.processor.Region")
+    async def test_update_webcam_success(
+        self,
+        mock_region,
+        mock_highway,
+        mock_webcam,
+        mock_status,
+    ):
+
+        mock_status.return_value = {
+            "mean_interval":10,
+            "stddev_interval":5,
+            "stale":False,
+            "delayed":False,
+        }
+
+        mock_region.objects.using.return_value.filter.return_value.first.return_value = MagicMock(
+            seq=1,
+            name="Region"
+        )
+
+
+        mock_highway.objects.using.return_value.filter.return_value.first.return_value = MagicMock(
+            seq=1
+        )
+
+
+        mock_webcam.objects.update_or_create.return_value = (
+            MagicMock(location=None),
+            True
+        )
+
+        await update_webcam(
+            1,
+            datetime.now(),
+            {
+                "cam_locations_region":1,
+                "cam_locations_highway":"1_Highway",
+                "is_on":True
+            }
+        )
+
+        mock_webcam.objects.update_or_create.assert_called_once()
+
+    @patch(
+        "apps.consumer.processor.setup_rabbitmq",
+        new_callable=AsyncMock,
+    )
+    def test_consume_from_amqp_error(self, mock_setup):
+        """consume_from retries when setup_rabbitmq raises AMQPConnectionError."""
+
+        processor.stop_event.clear()
+
+        async def setup_side_effect(*args, **kwargs):
+            processor.stop_event.set()
+            raise AMQPConnectionError()
+
+        mock_setup.side_effect = setup_side_effect
+
+        async def runner():
+            await consume_from("url", "GOLD")
+
+        asyncio.run(runner())
+
+        mock_setup.assert_called_once()

--- a/src/backend/apps/consumer/tests/test_tasks.py
+++ b/src/backend/apps/consumer/tests/test_tasks.py
@@ -18,20 +18,18 @@ class TestGenerateOfflineCameraImages(TestCase):
         cache.clear()
         Webcam.objects.all().delete()
 
-    @patch('apps.consumer.tasks.check_backup_exists')
+
     @patch('apps.consumer.tasks.get_all_from_db')
     @patch('apps.consumer.tasks.process_camera_rows')
     def test_generates_for_offline_cameras(
         self,
         mock_process_rows,
         mock_get_db,
-        mock_check_backup_exists,
     ):
         mock_get_db.return_value = []
         mock_process_rows.return_value = [
             {'id': 1, 'is_on': False, 'cam_internet_name': 'Camera 1'},
         ]
-        mock_check_backup_exists.return_value = False
 
         with patch('apps.consumer.tasks.delete_watermarked_image_from_pvc'), \
             patch('apps.consumer.tasks.save_watermarked_image_to_drivebc_pvc') as mock_save_drivebc:
@@ -41,7 +39,6 @@ class TestGenerateOfflineCameraImages(TestCase):
             mock_save_drivebc.assert_not_called()
 
     @patch("apps.consumer.tasks.save_watermarked_image_to_drivebc_pvc")
-    @patch("apps.consumer.tasks.check_backup_exists")
     @patch("apps.consumer.tasks.delete_offline_webcam_records")
     @patch("apps.consumer.tasks.delete_watermarked_image_from_pvc")
     @patch("apps.consumer.tasks.blank_out_image")
@@ -56,7 +53,6 @@ class TestGenerateOfflineCameraImages(TestCase):
         mock_blank_out_image,
         mock_delete_watermarked,
         mock_delete_records,
-        mock_check_backup_exists,
         mock_save_image,
     ):
 
@@ -81,8 +77,7 @@ class TestGenerateOfflineCameraImages(TestCase):
         # blank_out_image returns generated image bytes
         mock_blank_out_image.return_value = b"fake image bytes"
 
-        # No backup image exists, so save should happen
-        mock_check_backup_exists.return_value = False
+ 
 
         generate_offline_camera_images()
 

--- a/src/backend/apps/consumer/tests/test_tasks.py
+++ b/src/backend/apps/consumer/tests/test_tasks.py
@@ -18,89 +18,86 @@ class TestGenerateOfflineCameraImages(TestCase):
         cache.clear()
         Webcam.objects.all().delete()
 
+    @patch('apps.consumer.tasks.check_backup_exists')
     @patch('apps.consumer.tasks.get_all_from_db')
     @patch('apps.consumer.tasks.process_camera_rows')
-    def test_skips_online_cameras(self, mock_process_rows, mock_get_db):
-        mock_get_db.return_value = []
-        mock_process_rows.return_value = [
-            {'id': 1, 'is_on': True, 'cam_internet_name': 'Camera 1'},
-            {'id': 2, 'is_on': True, 'cam_internet_name': 'Camera 2'},
-        ]
-
-        with patch('apps.consumer.tasks.watermark') as mock_watermark, \
-             patch('apps.consumer.tasks.save_watermarked_image_to_pvc') as mock_save_pvc:
-
-            generate_offline_camera_images()
-
-            mock_watermark.assert_not_called()
-            mock_save_pvc.assert_not_called()
-            
-
-    @patch('apps.consumer.tasks.get_all_from_db')
-    @patch('apps.consumer.tasks.process_camera_rows')
-    def test_generates_for_offline_cameras(self, mock_process_rows, mock_get_db):
+    def test_generates_for_offline_cameras(
+        self,
+        mock_process_rows,
+        mock_get_db,
+        mock_check_backup_exists,
+    ):
         mock_get_db.return_value = []
         mock_process_rows.return_value = [
             {'id': 1, 'is_on': False, 'cam_internet_name': 'Camera 1'},
         ]
+        mock_check_backup_exists.return_value = False
 
-        with patch('apps.consumer.tasks.watermark') as mock_watermark, \
-             patch('apps.consumer.tasks.save_watermarked_image_to_pvc') as mock_save_pvc, \
-             patch('apps.consumer.tasks.delete_watermarked_image_from_pvc'), \
-             patch('apps.consumer.tasks.save_watermarked_image_to_drivebc_pvc') as mock_save_drivebc:
-
-            mock_watermark.return_value = b'watermarked_image_bytes'
+        with patch('apps.consumer.tasks.delete_watermarked_image_from_pvc'), \
+            patch('apps.consumer.tasks.save_watermarked_image_to_drivebc_pvc') as mock_save_drivebc:
 
             generate_offline_camera_images()
 
-            mock_save_pvc.assert_not_called()
-            mock_save_drivebc.assert_called_once()
+            mock_save_drivebc.assert_not_called()
 
-    @patch('apps.consumer.tasks.get_all_from_db')
-    @patch('apps.consumer.tasks.process_camera_rows')
-    def test_handles_empty_camera_list(self, mock_process_rows, mock_get_db):
-        mock_get_db.return_value = []
-        mock_process_rows.return_value = []
+    @patch("apps.consumer.tasks.save_watermarked_image_to_drivebc_pvc")
+    @patch("apps.consumer.tasks.check_backup_exists")
+    @patch("apps.consumer.tasks.delete_offline_webcam_records")
+    @patch("apps.consumer.tasks.delete_watermarked_image_from_pvc")
+    @patch("apps.consumer.tasks.blank_out_image")
+    @patch("apps.consumer.tasks.Webcam")
+    @patch("apps.consumer.tasks.process_camera_rows")
+    @patch("apps.consumer.tasks.get_all_from_db")
+    def test_generate_offline_camera_images_saves_blank_image(
+        self,
+        mock_get_all_from_db,
+        mock_process_camera_rows,
+        mock_webcam,
+        mock_blank_out_image,
+        mock_delete_watermarked,
+        mock_delete_records,
+        mock_check_backup_exists,
+        mock_save_image,
+    ):
 
-        with patch('apps.consumer.tasks.watermark') as mock_watermark, \
-             patch('apps.consumer.tasks.save_watermarked_image_to_pvc') as mock_save_pvc:
+        camera = {
+            "id": 1001,
+            "is_on": False,
+            "message": {
+                "long": "Camera offline"
+            },
+            "dbc_mark": "DriveBC",
+        }
 
-            generate_offline_camera_images()
+        # DB source data
+        mock_get_all_from_db.return_value = ["row"]
 
-            mock_watermark.assert_not_called()
-            mock_save_pvc.assert_not_called()
+        # Processed camera list
+        mock_process_camera_rows.return_value = [camera]
 
-    @patch('apps.consumer.tasks.get_all_from_db')
-    @patch('apps.consumer.tasks.process_camera_rows')
-    def test_handles_watermark_failure(self, mock_process_rows, mock_get_db):
-        mock_get_db.return_value = []
-        mock_process_rows.return_value = [
-            {'id': 1, 'is_on': False, 'cam_internet_name': 'Camera 1', 'camera_id': '1'},
-        ]
+        # Webcam exists in Postgres
+        mock_webcam.filter.return_value.exists.return_value = True
 
-        with patch('apps.consumer.tasks.save_watermarked_image_to_pvc') as mock_save_pvc, \
-             patch('apps.consumer.tasks.save_watermarked_image_to_drivebc_pvc') as mock_save_drivebc, \
-             patch('apps.consumer.tasks.delete_watermarked_image_from_pvc'):
+        # blank_out_image returns generated image bytes
+        mock_blank_out_image.return_value = b"fake image bytes"
 
-            generate_offline_camera_images()
+        # No backup image exists, so save should happen
+        mock_check_backup_exists.return_value = False
 
-            mock_save_pvc.assert_not_called()
-            mock_save_drivebc.assert_called_once()
+        generate_offline_camera_images()
 
-    @patch('apps.consumer.tasks.get_all_from_db')
-    @patch('apps.consumer.tasks.process_camera_rows')
-    def test_handles_is_on_key_missing(self, mock_process_rows, mock_get_db):
-        mock_get_db.return_value = []
-        mock_process_rows.return_value = [
-            {'id': 1, 'cam_internet_name': 'Camera 1'},
-        ]
+        # Verify offline branch executed
+        mock_blank_out_image.assert_called_once()
 
-        with patch('apps.consumer.tasks.watermark') as mock_watermark, \
-             patch('apps.consumer.tasks.save_watermarked_image_to_pvc') as mock_save_pvc:
+        # Verify old images removed
+        mock_delete_watermarked.assert_called_once_with("1001")
 
-            mock_watermark.return_value = b'watermarked_image_bytes'
+        # Verify old DB records removed
+        mock_delete_records.assert_called_once_with("1001")
 
-            generate_offline_camera_images()
-
-            mock_watermark.assert_not_called()
-            mock_save_pvc.assert_not_called()
+        # Verify new blank image saved
+        mock_save_image.assert_called_once_with(
+            "1001",
+            b"fake image bytes",
+            False,
+        )

--- a/src/backend/apps/webcam/admin.py
+++ b/src/backend/apps/webcam/admin.py
@@ -11,7 +11,7 @@ from timezonefinder import TimezoneFinder
 
 
 class WebcamAdmin(admin.GISModelAdmin):
-    readonly_fields = ('id', )
+    readonly_fields = ('id',)
     gis_widget = DriveBCMapWidget
     change_form_template = "admin/timelapse.html"  # custom template
 

--- a/src/backend/apps/webcam/enums.py
+++ b/src/backend/apps/webcam/enums.py
@@ -6,6 +6,8 @@ CAMERA_DIFF_FIELDS = [
     'should_appear',
     'marked_stale',
     'marked_delayed',
+    'update_period_mean',
+    'update_period_stddev',
     'local_weather_station_id'
 ]
 
@@ -16,6 +18,8 @@ CAMERA_FIELD_MAPPING = {
     'should_appear': 'cam_controldisappear',
     'marked_stale': 'stale',
     'marked_delayed': 'delayed',
+    'update_period_mean': 'mean_interval',
+    'update_period_stddev': 'stddev_interval',
     'local_weather_station_id': 'cam_locationsweather_station'
 
 }

--- a/src/backend/apps/webcam/models.py
+++ b/src/backend/apps/webcam/models.py
@@ -90,6 +90,7 @@ class Webcam(ExportModelOperationsMixin('webcam'), BaseModel):
         # PointField stores as (x=lon, y=lat)
         tzname = tf.timezone_at(lng=self.location.x, lat=self.location.y)
         return pytz.timezone(tzname) if tzname else timezone.utc
+    
 
 
 class Region(models.Model):

--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -132,6 +132,35 @@ def update_cam_from_sql_db(id: int, current_time: datetime.datetime):
     except Exception as e:
         logging.exception(f"Failed to query camera from ORM: {e}")
         return {}
+    
+def update_cam_is_on_from_sql_db(id: int):
+    try:
+        cam = (
+            CameraSource.objects.using("mssql")
+            .filter(id=id)
+            .annotate(
+                isOn=Case(
+                    When(cam_controldisabled=0, then=Value(True)),
+                    default=Value(False),
+                    output_field=BooleanField()
+                ),
+            )
+            .values(
+                'id',
+                'isOn',
+            )
+            .first()
+        )
+
+        if cam:
+            update_webcam_is_on_status(id, cam)
+            return True
+        else:
+            return False
+
+    except Exception as e:
+        logging.exception(f"Failed to query camera from ORM: {e}")
+        return {}
 
 
 def format_region_name(region_name):
@@ -200,7 +229,6 @@ def update_webcam_db(cam_id: int, cam_data: dict):
         return False
 
     update_data = {
-        "is_on": True if cam_data.get("isOn") == 1 else False,
         "should_appear": True if cam_data.get("should_appear") == 1 else False,
         "name": cam_data.get("cam_internetname"),
         "caption": cam_data.get("cam_internetcaption"),
@@ -214,6 +242,20 @@ def update_webcam_db(cam_id: int, cam_data: dict):
 
     Webcam.objects.filter(id=cam_id).update(**update_data)
     return True
+
+def update_webcam_is_on_status(cam_id: int, cam_data: dict):
+    is_on = cam_data.get("isOn") == 1
+
+    webcam = Webcam.objects.only("id", "is_on").filter(id=cam_id).first()
+    if not webcam:
+        return False
+
+    # Detect OFF -> ON transition
+    if webcam.is_on != is_on:
+        Webcam.objects.filter(id=cam_id).update(is_on=is_on)
+
+    return True
+
 
 
 
@@ -318,13 +360,7 @@ def purge_old_pvc_images(age: str = "24"):
             full_path = path
 
         files_to_delete.append(full_path)
-        ids_to_delete.append(row.timestamp)
-
-    ImageIndex.objects.filter(
-            timestamp__in=ids_to_delete,
-        ).update(
-            modified_at=timezone.now()
-        )
+        ids_to_delete.append(row.pk)
 
     # Delete files from PVC or s3
     logger.info(f"Deleting {len(files_to_delete)} old PVC images...")
@@ -340,9 +376,7 @@ def purge_old_pvc_images(age: str = "24"):
             logging.exception(f"Error deleting file {file_path}: {e}")
 
     # Delete all records if all images paths are NULL
-    ImageIndex.objects.filter(
-        timestamp__in=ids_to_delete,
-    ).delete()
+    ImageIndex.objects.filter(pk__in=ids_to_delete).delete()
 
     logger.info("All purged recordes are deleted successfully.")
 
@@ -408,6 +442,7 @@ def update_single_webcam_data(webcam):
         if getattr(webcam, field) != getattr(webcam_data, source_field):
             current_time = datetime.datetime.now(tz=ZoneInfo("America/Vancouver"))
             update_cam_from_sql_db(webcam.id, current_time)
+    update_cam_is_on_from_sql_db(webcam.id)
     return False
 
 
@@ -424,8 +459,15 @@ def update_all_webcam_data():
             updated = update_cam_from_sql_db(camera.id, current_time)
             if updated:
                 update_camera_group_id(camera)
+        update_cam_is_on_from_sql_db(camera.id)
     cache.delete(CacheKey.WEBCAM_LIST)
 
+def update_camera_is_on_status():
+    for camera in Webcam.objects.all():
+        updated = update_cam_is_on_from_sql_db(camera.id)
+        if updated:
+            update_camera_group_id(camera)
+    
 
 def wrap_text(text, pen, font, width):
     '''

--- a/src/backend/apps/webcam/tests/test_tasks.py
+++ b/src/backend/apps/webcam/tests/test_tasks.py
@@ -1,15 +1,14 @@
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 import time
 from django.test import TestCase
-from apps.webcam.tasks import backup_purge_old_images, backup_purge_old_pvc_images, populate_all_webcam_data, purge_old_images, purge_old_pvc_images, restore_backup_image, update_cam_is_on_from_sql_db, update_camera_is_on_status, update_camera_is_on_status, update_webcam_is_on_status, wrap_text
+from apps.webcam.tasks import backup_purge_old_images, backup_purge_old_pvc_images, populate_all_webcam_data, purge_old_images, purge_old_pvc_images, update_cam_is_on_from_sql_db, update_camera_is_on_status, update_camera_is_on_status, update_webcam_is_on_status, wrap_text
 
 from apps.consumer.processor import (
     on_reconnect,
     on_close,
     on_channel_close,
     save_original_image_to_pvc,
-    save_watermarked_image_to_drivebc_pvc,
     save_watermarked_image_to_pvc,
 )
 

--- a/src/backend/apps/webcam/tests/test_tasks.py
+++ b/src/backend/apps/webcam/tests/test_tasks.py
@@ -229,32 +229,10 @@ class TestOtherFunctions(TestCase):
 
         self.assertFalse(result)
 
-    @patch("apps.webcam.tasks.restore_backup_image")
-    @patch("apps.webcam.tasks.Webcam")
-    def test_update_webcam_status_db_restore_backup(
-        self,
-        mock_webcam,
-        mock_restore,
-    ):
-        webcam = MagicMock()
-        webcam.is_on = False
-
-        mock_webcam.objects.only.return_value.filter.return_value.first.return_value = webcam
-
-        result = update_webcam_is_on_status(123, {"isOn": 1})
-
-        self.assertTrue(result)
-        mock_restore.assert_called_once_with("123")
-        mock_webcam.objects.filter.return_value.update.assert_called_once_with(
-            is_on=True
-        )
-
-    @patch("apps.webcam.tasks.restore_backup_image")
     @patch("apps.webcam.tasks.Webcam")
     def test_update_webcam_status_db_already_on(
         self,
         mock_webcam,
-        mock_restore,
     ):
         webcam = MagicMock()
         webcam.is_on = True
@@ -264,10 +242,9 @@ class TestOtherFunctions(TestCase):
         result = update_webcam_is_on_status(123, {"isOn": 1})
 
         self.assertTrue(result)
-        mock_restore.assert_not_called()
+  
         mock_webcam.objects.filter.return_value.update.assert_not_called()
 
-    @patch("apps.webcam.tasks.restore_backup_image")
     @patch("apps.webcam.tasks.Webcam")
     def test_update_webcam_status_db_turn_off(
         self,
@@ -284,41 +261,6 @@ class TestOtherFunctions(TestCase):
         mock_webcam.objects.filter.return_value.update.assert_called_once_with(
             is_on=False
         )
-
-    @patch("apps.consumer.processor.logger")
-    @patch("apps.consumer.processor.shutil.move")
-    @patch("apps.consumer.processor.os.path.exists", return_value=True)
-    @patch("apps.consumer.processor.os.getenv", return_value="/tmp/images")
-    def test_restore_backup_image(
-        self,
-        mock_getenv,
-        mock_exists,
-        mock_move,
-        mock_logger,
-    ):
-        restore_backup_image("123")
-
-        mock_move.assert_called_once_with(
-            "/tmp/images/backup/123.jpg",
-            "/tmp/images/123.jpg",
-        )
-        mock_logger.info.assert_not_called()
-
-    @patch("apps.consumer.processor.logger")
-    @patch("apps.consumer.processor.shutil.move")
-    @patch("apps.consumer.processor.os.path.exists", return_value=False)
-    @patch("apps.consumer.processor.os.getenv", return_value="/tmp/images")
-    def test_restore_backup_image_not_found(
-        self,
-        mock_getenv,
-        mock_exists,
-        mock_move,
-        mock_logger,
-    ):
-        restore_backup_image("123")
-
-        mock_move.assert_not_called()
-        mock_logger.warning.assert_not_called()
 
     from unittest.mock import MagicMock
 

--- a/src/backend/apps/webcam/tests/test_tasks.py
+++ b/src/backend/apps/webcam/tests/test_tasks.py
@@ -1,0 +1,443 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, mock_open, patch
+import time
+from django.test import TestCase
+from apps.webcam.tasks import backup_purge_old_images, backup_purge_old_pvc_images, populate_all_webcam_data, purge_old_images, purge_old_pvc_images, restore_backup_image, update_cam_is_on_from_sql_db, update_camera_is_on_status, update_camera_is_on_status, update_webcam_is_on_status, wrap_text
+
+from apps.consumer.processor import (
+    check_backup_exists,
+    on_reconnect,
+    on_close,
+    on_channel_close,
+    save_original_image_to_pvc,
+    save_watermarked_image_to_drivebc_pvc,
+    save_watermarked_image_to_pvc,
+)
+
+
+class TestRabbitMQCallbacks(IsolatedAsyncioTestCase):
+
+    @patch("apps.consumer.processor.logger")
+    async def test_on_reconnect(self, mock_logger):
+        conn = MagicMock()
+
+        before = time.time()
+
+        await on_reconnect(conn)
+
+        mock_logger.info.assert_called_once_with(
+            "RabbitMQ connection re-established"
+        )
+
+        from apps.consumer import processor
+        self.assertGreaterEqual(processor.last_activity, before)
+
+    @patch("apps.consumer.processor.logger")
+    async def test_on_close(self, mock_logger):
+        conn = MagicMock()
+        exc = Exception("connection lost")
+
+        await on_close(conn, exc)
+
+        mock_logger.warning.assert_called_once_with(
+            f"RabbitMQ connection closed: {exc}"
+        )
+
+    @patch("apps.consumer.processor.logger")
+    async def test_on_close_without_exception(self, mock_logger):
+        conn = MagicMock()
+
+        await on_close(conn)
+
+        mock_logger.warning.assert_called_once_with(
+            "RabbitMQ connection closed: None"
+        )
+
+    @patch("apps.consumer.processor.logger")
+    async def test_on_channel_close(self, mock_logger):
+        channel = MagicMock()
+        exc = Exception("channel closed")
+
+        await on_channel_close(channel, exc)
+
+        mock_logger.warning.assert_called_once_with(
+            f"RabbitMQ channel closed: {exc}"
+        )
+
+    @patch("apps.consumer.processor.logger")
+    async def test_on_channel_close_without_exception(self, mock_logger):
+        channel = MagicMock()
+
+        await on_channel_close(channel)
+
+        mock_logger.warning.assert_called_once_with(
+            "RabbitMQ channel closed: None"
+        )
+
+
+class TestUpdateCamStatusFromSqlDb(TestCase):
+
+    @patch("apps.webcam.tasks.CameraSource")
+    def test_update_cam_is_on_from_sql_db_exception(
+        self,
+        mock_camera_source,
+    ):
+        mock_camera_source.objects.using.side_effect = Exception("Database error")
+
+        result = update_cam_is_on_from_sql_db(1)
+
+        self.assertEqual(result, {})
+
+class TestOtherFunctions(TestCase):
+
+    @patch("apps.consumer.processor.logging.exception")
+    @patch("builtins.open", side_effect=OSError("Disk full"))
+    @patch("apps.consumer.processor.PVC_ORIGINAL_PATH", "/tmp/images/original")
+    def test_save_original_image_to_pvc_exception(
+        self,
+        mock_open,
+        mock_exception,
+    ):
+        save_original_image_to_pvc("123", b"image")
+
+        mock_exception.assert_called_once()
+
+    @patch("apps.consumer.processor.logging.exception")
+    @patch("builtins.open", side_effect=OSError("Disk full"))
+    @patch("apps.consumer.processor.PVC_WATERMARKED_PATH", "/tmp/images/watermarked")
+    def test_save_watermarked_image_to_pvc_exception(
+        self,
+        mock_open,
+        mock_exception,
+    ):
+        save_watermarked_image_to_pvc(
+            "123",
+            b"image",
+            "20250101000000",
+            True,
+        )
+
+        mock_exception.assert_called_once()
+
+    @patch("apps.consumer.processor.os.path.exists")
+    @patch("apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH", "/tmp/images")
+    def test_check_backup_exists_true(self, mock_exists):
+        mock_exists.return_value = True
+
+        self.assertTrue(check_backup_exists("123"))
+
+    @patch("apps.consumer.processor.check_backup_exists")
+    @patch("apps.consumer.processor.shutil.move")
+    @patch("apps.consumer.processor.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_backup_already_exists(
+        self,
+        mock_file,
+        mock_exists,
+        mock_move,
+        mock_backup,
+    ):
+        mock_exists.return_value = True
+        mock_backup.return_value = True
+        with patch(
+            "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
+            "/tmp/images",
+        ):
+            save_watermarked_image_to_drivebc_pvc(
+                "123",
+                b"image",
+                False,
+            )
+
+        mock_move.assert_not_called()
+
+    @patch("apps.consumer.processor.check_backup_exists")
+    @patch("apps.consumer.processor.shutil.move")
+    @patch("apps.consumer.processor.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_backup_created(
+        self,
+        mock_file,
+        mock_exists,
+        mock_move,
+        mock_backup,
+    ):
+        mock_exists.return_value = True
+        mock_backup.return_value = False
+
+        with patch(
+            "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
+            "/tmp/images",
+        ):
+            save_watermarked_image_to_drivebc_pvc(
+                "123",
+                b"image",
+                False,
+            )
+
+        mock_move.assert_called_once()
+
+
+    @patch("apps.webcam.tasks.purge_old_pvc_images")
+    @patch("apps.consumer.processor.os.getenv")
+    def test_purge_old_images(self, mock_getenv, mock_purge):
+        mock_getenv.return_value = "48"
+
+        purge_old_images()
+
+        mock_getenv.assert_called_once_with("REPLAY_THE_DAY_HOURS")
+        mock_purge.assert_called_once_with(age="48")
+
+    @patch("apps.webcam.tasks.backup_purge_old_pvc_images")
+    def test_backup_purge_old_images(self, mock_backup):
+        backup_purge_old_images()
+
+        mock_backup.assert_called_once()
+
+    
+    @patch("apps.consumer.processor.os.remove")
+    @patch("apps.consumer.processor.ImageIndex")
+    def test_purge_old_pvc_images(self, mock_image_index, mock_remove):
+
+        mock_row = MagicMock()
+        mock_row.camera_id = "123"
+        mock_row.timestamp.strftime.return_value = "20250101000000"
+        mock_queryset = MagicMock()
+        mock_queryset.__iter__.return_value = [mock_row]
+        mock_image_index.objects.filter.return_value = mock_queryset
+        with patch(
+            "apps.consumer.processor.PVC_WATERMARKED_PATH",
+            "/tmp/images",
+        ):
+            print(mock_image_index.objects.filter.return_value)
+            print(list(mock_queryset))
+            purge_old_pvc_images(age="24")
+        mock_remove.assert_not_called()
+
+
+    @patch("apps.consumer.processor.os.remove")
+    @patch("apps.consumer.processor.os.walk")
+    @patch("apps.consumer.processor.time.time")
+    @patch("apps.consumer.processor.os.getenv")
+    def test_backup_purge_old_pvc_images_delete(
+        self,
+        mock_getenv,
+        mock_time,
+        mock_walk,
+        mock_remove,
+    ):
+        mock_getenv.return_value = "/tmp"
+
+        mock_time.return_value = 100000
+
+        mock_walk.return_value = [
+            ("/tmp", [], ["a.jpg"])
+        ]
+
+        stat = MagicMock()
+        stat.st_mtime = 1
+
+        with patch("pathlib.Path.stat", return_value=stat):
+            backup_purge_old_pvc_images()
+
+        mock_remove.assert_called_once()
+
+    @patch("apps.consumer.processor.logging.exception")
+    @patch("apps.consumer.processor.os.walk")
+    @patch("apps.consumer.processor.os.getenv")
+    def test_backup_purge_old_pvc_images_exception(
+        self,
+        mock_getenv,
+        mock_walk,
+        mock_exception,
+    ):
+        mock_getenv.return_value = "/tmp"
+
+        mock_walk.return_value = [
+            ("/tmp", [], ["a.jpg"])
+        ]
+
+        with patch(
+            "pathlib.Path.stat",
+            side_effect=Exception("boom"),
+        ):
+            backup_purge_old_pvc_images()
+
+        mock_exception.assert_called()
+
+    @patch("apps.webcam.tasks.populate_webcam_from_data")
+    @patch("apps.webcam.tasks.FeedClient")
+    def test_populate_all_webcam_data(
+        self,
+        mock_feed,
+        mock_populate,
+    ):
+        mock_feed.return_value.get_webcam_list.return_value = [
+            {"id": 1},
+            {"id": 2},
+        ]
+
+        populate_all_webcam_data()
+
+        self.assertEqual(mock_populate.call_count, 2)
+
+    @patch("apps.webcam.tasks.Webcam")
+    def test_update_webcam_status_db_not_found(self, mock_webcam):
+        mock_webcam.objects.only.return_value.filter.return_value.first.return_value = None
+
+        result = update_webcam_is_on_status(123, {"isOn": 1})
+
+        self.assertFalse(result)
+
+    @patch("apps.webcam.tasks.restore_backup_image")
+    @patch("apps.webcam.tasks.Webcam")
+    def test_update_webcam_status_db_restore_backup(
+        self,
+        mock_webcam,
+        mock_restore,
+    ):
+        webcam = MagicMock()
+        webcam.is_on = False
+
+        mock_webcam.objects.only.return_value.filter.return_value.first.return_value = webcam
+
+        result = update_webcam_is_on_status(123, {"isOn": 1})
+
+        self.assertTrue(result)
+        mock_restore.assert_called_once_with("123")
+        mock_webcam.objects.filter.return_value.update.assert_called_once_with(
+            is_on=True
+        )
+
+    @patch("apps.webcam.tasks.restore_backup_image")
+    @patch("apps.webcam.tasks.Webcam")
+    def test_update_webcam_status_db_already_on(
+        self,
+        mock_webcam,
+        mock_restore,
+    ):
+        webcam = MagicMock()
+        webcam.is_on = True
+
+        mock_webcam.objects.only.return_value.filter.return_value.first.return_value = webcam
+
+        result = update_webcam_is_on_status(123, {"isOn": 1})
+
+        self.assertTrue(result)
+        mock_restore.assert_not_called()
+        mock_webcam.objects.filter.return_value.update.assert_not_called()
+
+    @patch("apps.webcam.tasks.restore_backup_image")
+    @patch("apps.webcam.tasks.Webcam")
+    def test_update_webcam_status_db_turn_off(
+        self,
+        mock_webcam,
+        mock_restore,
+    ):
+        webcam = MagicMock()
+        webcam.is_on = True
+
+        mock_webcam.objects.only.return_value.filter.return_value.first.return_value = webcam
+
+        result = update_webcam_is_on_status(123, {"isOn": 0})
+
+        self.assertTrue(result)
+        mock_restore.assert_not_called()
+        mock_webcam.objects.filter.return_value.update.assert_called_once_with(
+            is_on=False
+        )
+
+    @patch("apps.consumer.processor.logger")
+    @patch("apps.consumer.processor.shutil.move")
+    @patch("apps.consumer.processor.os.path.exists", return_value=True)
+    @patch("apps.consumer.processor.os.getenv", return_value="/tmp/images")
+    def test_restore_backup_image(
+        self,
+        mock_getenv,
+        mock_exists,
+        mock_move,
+        mock_logger,
+    ):
+        restore_backup_image("123")
+
+        mock_move.assert_called_once_with(
+            "/tmp/images/backup/123.jpg",
+            "/tmp/images/123.jpg",
+        )
+        mock_logger.info.assert_not_called()
+
+    @patch("apps.consumer.processor.logger")
+    @patch("apps.consumer.processor.shutil.move")
+    @patch("apps.consumer.processor.os.path.exists", return_value=False)
+    @patch("apps.consumer.processor.os.getenv", return_value="/tmp/images")
+    def test_restore_backup_image_not_found(
+        self,
+        mock_getenv,
+        mock_exists,
+        mock_move,
+        mock_logger,
+    ):
+        restore_backup_image("123")
+
+        mock_move.assert_not_called()
+        mock_logger.warning.assert_not_called()
+
+    from unittest.mock import MagicMock
+
+    def test_wrap_text_single_line(self):
+        pen = MagicMock()
+        font = MagicMock()
+
+        pen.textlength.return_value = 20
+
+        result = wrap_text(
+            "hello world",
+            pen,
+            font,
+            width=100,
+        )
+
+        self.assertEqual(result, "hello world")
+
+    from unittest.mock import MagicMock
+
+    def test_wrap_text_multiple_lines(self):
+        pen = MagicMock()
+        font = MagicMock()
+
+        pen.textlength.return_value = 50
+
+        result = wrap_text(
+            "one two three",
+            pen,
+            font,
+            width=75,
+        )
+
+        self.assertEqual(result, "one\ntwo\nthree")
+
+
+    @patch("apps.webcam.tasks.update_camera_group_id")
+    @patch("apps.webcam.tasks.update_cam_is_on_from_sql_db")
+    @patch("apps.webcam.tasks.Webcam")
+    def test_update_camera_is_on_status(
+        self,
+        mock_webcam,
+        mock_update_status,
+        mock_update_group,
+    ):
+        camera1 = MagicMock(id=1)
+        camera2 = MagicMock(id=2)
+
+        mock_webcam.objects.all.return_value = [camera1, camera2]
+
+        # First camera updated, second not
+        mock_update_status.side_effect = [True, False]
+
+        update_camera_is_on_status()
+
+        self.assertEqual(mock_update_status.call_count, 2)
+        mock_update_status.assert_any_call(1)
+        mock_update_status.assert_any_call(2)
+
+        mock_update_group.assert_called_once_with(camera1)

--- a/src/backend/apps/webcam/tests/test_tasks.py
+++ b/src/backend/apps/webcam/tests/test_tasks.py
@@ -272,7 +272,6 @@ class TestOtherFunctions(TestCase):
     def test_update_webcam_status_db_turn_off(
         self,
         mock_webcam,
-        mock_restore,
     ):
         webcam = MagicMock()
         webcam.is_on = True
@@ -282,7 +281,6 @@ class TestOtherFunctions(TestCase):
         result = update_webcam_is_on_status(123, {"isOn": 0})
 
         self.assertTrue(result)
-        mock_restore.assert_not_called()
         mock_webcam.objects.filter.return_value.update.assert_called_once_with(
             is_on=False
         )

--- a/src/backend/apps/webcam/tests/test_tasks.py
+++ b/src/backend/apps/webcam/tests/test_tasks.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 from apps.webcam.tasks import backup_purge_old_images, backup_purge_old_pvc_images, populate_all_webcam_data, purge_old_images, purge_old_pvc_images, restore_backup_image, update_cam_is_on_from_sql_db, update_camera_is_on_status, update_camera_is_on_status, update_webcam_is_on_status, wrap_text
 
 from apps.consumer.processor import (
-    check_backup_exists,
     on_reconnect,
     on_close,
     on_channel_close,
@@ -118,64 +117,6 @@ class TestOtherFunctions(TestCase):
         )
 
         mock_exception.assert_called_once()
-
-    @patch("apps.consumer.processor.os.path.exists")
-    @patch("apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH", "/tmp/images")
-    def test_check_backup_exists_true(self, mock_exists):
-        mock_exists.return_value = True
-
-        self.assertTrue(check_backup_exists("123"))
-
-    @patch("apps.consumer.processor.check_backup_exists")
-    @patch("apps.consumer.processor.shutil.move")
-    @patch("apps.consumer.processor.os.path.exists")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_backup_already_exists(
-        self,
-        mock_file,
-        mock_exists,
-        mock_move,
-        mock_backup,
-    ):
-        mock_exists.return_value = True
-        mock_backup.return_value = True
-        with patch(
-            "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
-            "/tmp/images",
-        ):
-            save_watermarked_image_to_drivebc_pvc(
-                "123",
-                b"image",
-                False,
-            )
-
-        mock_move.assert_not_called()
-
-    @patch("apps.consumer.processor.check_backup_exists")
-    @patch("apps.consumer.processor.shutil.move")
-    @patch("apps.consumer.processor.os.path.exists")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_backup_created(
-        self,
-        mock_file,
-        mock_exists,
-        mock_move,
-        mock_backup,
-    ):
-        mock_exists.return_value = True
-        mock_backup.return_value = False
-
-        with patch(
-            "apps.consumer.processor.DRIVEBC_PVC_WATERMARKED_PATH",
-            "/tmp/images",
-        ):
-            save_watermarked_image_to_drivebc_pvc(
-                "123",
-                b"image",
-                False,
-            )
-
-        mock_move.assert_called_once()
 
 
     @patch("apps.webcam.tasks.purge_old_pvc_images")


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6169
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6979
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6982
- [x] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6990

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev.
2. Go to a camera detail page.
3. Turn on a camera (i.e., camera 11) from camera control panel. (https://dev.drivebc.ca/cameras/11?pan=-118.21833040000001%2C51.0072615&zoom=12)
4. Verify the unavailable image shows up within a min.
5. Verify the image is a blank image. (https://dev.drivebc.ca/images/11.jpg).
6. Turn the camera back on.
7. Verify the image shows up within a min.
8. Verify the image is not a blank image.
9. This ticket combined fixes for reducing update database call when updating Webcam database, verify Excessive UPDATE queries are removed by reviewing WAL log.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented