### PR TITLE
DBC22-6922: update border crossing hours of operation links

### DIFF
--- a/src/backend/apps/border/fixtures/border_data.json
+++ b/src/backend/apps/border/fixtures/border_data.json
@@ -7,7 +7,7 @@
         "modified_at": "2025-03-04T23:26:14.135Z",
         "name": "Peace Arch",
         "location": "SRID=4326;POINT (-122.755215373302 49.0004903332751)",
-        "schedule_url": "https://cbsa-asfc.gc.ca/do-rb/offices-bureaux/405-eng.html"
+        "schedule_url": "https://do-rb.cbsa-asfc.cloud-nuage.canada.ca/?lang=en_CA&id=405"
     }
 },
 {
@@ -18,7 +18,7 @@
         "modified_at": "2025-03-04T23:26:14.182Z",
         "name": "Pacific Highway",
         "location": "SRID=4326;POINT (-122.735322148821 49.0040969132511)",
-        "schedule_url": "https://cbsa-asfc.gc.ca/do-rb/offices-bureaux/398-eng.html"
+        "schedule_url": "https://do-rb.cbsa-asfc.cloud-nuage.canada.ca/?lang=en_CA&id=398"
     }
 },
 {
@@ -29,7 +29,7 @@
         "modified_at": "2025-03-04T23:26:14.187Z",
         "name": "Lynden/Aldergrove",
         "location": "SRID=4326;POINT (-122.485026353147 49.0004223841645)",
-        "schedule_url": "https://cbsa-asfc.gc.ca/do-rb/offices-bureaux/408-eng.html"
+        "schedule_url": "https://do-rb.cbsa-asfc.cloud-nuage.canada.ca/?lang=en_CA&id=408"
     }
 },
 {
@@ -40,7 +40,7 @@
         "modified_at": "2025-03-04T23:26:14.190Z",
         "name": "Sumas/Huntingdon",
         "location": "SRID=4326;POINT (-122.265219 49.004678)",
-        "schedule_url": "https://cbsa-asfc.gc.ca/do-rb/offices-bureaux/404-eng.html"
+        "schedule_url": "https://do-rb.cbsa-asfc.cloud-nuage.canada.ca/?lang=en_CA&id=404"
     }
 },
 {

--- a/src/backend/apps/border/migrations/0003_update_schedule_urls.py
+++ b/src/backend/apps/border/migrations/0003_update_schedule_urls.py
@@ -1,0 +1,17 @@
+from django.core.management import call_command
+from django.db import migrations
+
+
+def load_fixture(apps, schema_editor):
+    call_command('loaddata', 'border_data.json')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('border', '0002_bordercrossing_schedule_url'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_fixture, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** [DBC22-6922](https://moti-imb.atlassian.net/browse/DBC22-6922)

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Open DriveBC and click any border crossing icon (Pacific Highway, Peace Arch, Lynden/Aldergrove, Sumas/Huntingdon).
2. On the border crossing sidepanel, click the "hours of operation" link.
3. Confirm each link opens the new CBSA cloud directory page for that office (ids 398, 405, 408, 404) instead of the stale placeholder notice.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
