### PR TITLE
DBC22-6869: hide Wildfire View details when no incident URL

### DIFF
--- a/src/frontend/src/Components/map/panels/WildfirePanel.js
+++ b/src/frontend/src/Components/map/panels/WildfirePanel.js
@@ -133,9 +133,11 @@ export default function WildfirePanel(props) {
             </div>
           </div>
 
-          <div className="url-btn" >
-            <a href={wildfire.url} rel="noreferrer">View details</a>
-          </div>
+          {wildfire.url &&
+            <div className="url-btn">
+              <a href={wildfire.url} rel="noreferrer">View details</a>
+            </div>
+          }
         </div>
 
         <div className="popup__content__footer">


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6869](https://moti-imb.atlassian.net/browse/DBC22-6869)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Open a wildfire that previously showed plain-text "View details" (e.g. fires without WFS polygon data such as G80488, K20789, V10674 on test/prod).
2. Confirm "View details" is hidden when there is no incident URL.
3. Open a wildfire that has a valid detail URL and confirm "View details" is a working hyperlink to the BC Wildfire Service incident page.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
