### PR TITLE
DBC22-6807: only show WiFi for rest areas that have it

### DIFF
--- a/src/frontend/src/Components/map/panels/RestStopPanel.js
+++ b/src/frontend/src/Components/map/panels/RestStopPanel.js
@@ -33,25 +33,25 @@ import './RestStopPanel.scss';
 // Automatic title case conversion for Rest Stop Names and Distance from Municipality
 const toTitleCase = (str) => {
   if (!str) return '';
-  
+
   // 1. Normalize to lowercase, then split by separators (spaces, hyphens, slashes, parens, @).
   return str.toLowerCase().split(/(\s+|-|\/|\(|\)|@)/).map((word, index) => {
-    
+
     // 2. Return separators as is
     if (/^(\s+|-|\/|\(|\)|@)$/.test(word)) return word;
-    
+
     // 3. Handle words that should always be UPPERCASE
     if (['bc', 'sb', 'nb', 'eb', 'wb'].includes(word)) return word.toUpperCase();
-    
+
     // 4. Handle words that should always be lowercase
     if (word === 'km' || word === 'kms') return word;
     if (word === 'of' && index > 0) return word;
-    
+
     // 5. Handle "Mc" surnames (e.g., McBride, McRae)
     if (word.startsWith('mc') && word.length > 2) {
       return 'Mc' + word.charAt(2).toUpperCase() + word.slice(3);
     }
-    
+
     // 6. Default: Capitalize the first letter
     return word.charAt(0).toUpperCase() + word.slice(1);
   }).join('');
@@ -221,10 +221,10 @@ export default function RestStopPanel(props) {
                 Wi-Fi
               </p>
               <p className="data">
-              {restStopData.properties.WI_FI === "No" ? (
-                `Unavailable`
-              ) : (
+              {restStopData.properties.WI_FI === "Y" || restStopData.properties.WI_FI === "Yes" ? (
                 `Available`
+              ) : (
+                `Unavailable`
               )}
               </p>
             </div>


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** [DBC22-6807](https://moti-imb.atlassian.net/browse/DBC22-6807)

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [x] **Tested desktop** in local or dev envs 
- [x] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [x] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Open DriveBC map and enable rest areas.
2. Click several rest area icons that do not have WiFi — confirm WiFi is not listed as available.
3. Click rest areas that do have WiFi (if known) — confirm WiFi is listed.
4. Confirm the majority of rest areas no longer incorrectly show WiFi.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
