### PR TITLE
DBC22-6874: fix Bulletin header unread count pill

### DIFF
--- a/src/frontend/src/Components/shared/header/Header.js
+++ b/src/frontend/src/Components/shared/header/Header.js
@@ -102,18 +102,14 @@ export default function Header({ isMaintenance }) {
       return 0;
     }
 
-    if (advisoriesData.length !== 0 && advisoriesData[0].last_notified_at == null) {
-      return 0;
-    }
-
     const readAdvisories = advisoriesData.filter(advisory => {
-      // Do not count preview items as unread
+      // Do not count preview items or never-notified items as unread
       if (!advisory.id || !advisory.last_notified_at) {
         return true;
       }
 
       return cmsContext.readAdvisories.includes(
-        advisory.id.toString() + '-' + advisory.last_notified_at
+        advisory.id.toString() + '-' + advisory.last_notified_at.toString()
       );
     });
 
@@ -125,13 +121,17 @@ export default function Header({ isMaintenance }) {
       return 0;
     }
 
-    if (bulletinsData.length !== 0 && bulletinsData[0].last_notified_at == null) {
-      return 0;
-    }
+    const readBulletins = bulletinsData.filter(bulletin => {
+      // Do not count preview items or never-notified items as unread
+      if (!bulletin.id || !bulletin.last_notified_at) {
+        return true;
+      }
 
-    const readBulletins = bulletinsData.filter(bulletin => cmsContext.readBulletins.includes(
-      bulletin.id.toString() + '-' + bulletin.last_notified_at
-    ));
+      return cmsContext.readBulletins.includes(
+        bulletin.id.toString() + '-' + bulletin.last_notified_at.toString()
+      );
+    });
+
     return bulletinsData.length - readBulletins.length;
   }
 


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6874](https://moti-imb.atlassian.net/browse/DBC22-6874)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Open DriveBC and note the Bulletins nav item (header unread pill may be missing before this fix).
2. In CMS, create or edit a Bulletin and click **Publish with notifications**.
3. Confirm the Bulletins header item shows an update pill with the correct unread count (e.g. `1`).
4. Repeat with an Advisory and confirm Advisories header pill still works.
5. Optional: if other bulletins have never been published with notifications (`last_notified_at` null), confirm they do not suppress the count for notified ones.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
