### PR TITLE
DBC22-6876: keep unread indicators after viewing one item

### DIFF
--- a/src/frontend/src/pages/AdvisoriesListPage.js
+++ b/src/frontend/src/pages/AdvisoriesListPage.js
@@ -204,14 +204,6 @@ useEffect(() => {
   loadAdvisories();
 }, [location.key]);
 
-useEffect(() => {
-  return () => {
-    if (advisoriesRef.current && advisoriesRef.current.length) {
-      markAdvisoriesAsRead(advisoriesRef.current, cmsContextRef.current, setCMSContext);
-    }
-  };
-}, []);
-
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {

--- a/src/frontend/src/pages/BulletinsListPage.js
+++ b/src/frontend/src/pages/BulletinsListPage.js
@@ -49,7 +49,7 @@ export default function BulletinsListPage() {
   const dismissedHighlightsRef = useRef(
     new Set(JSON.parse(sessionStorage.getItem('dismissedBulletinHighlights') || '[]'))
   );
-  
+
 
   // States
   const [showLoader, setShowLoader] = useState(true);
@@ -158,7 +158,7 @@ export default function BulletinsListPage() {
 
   useEffect(() => {
     cmsContextRef.current = cmsContext;
-  
+
     if (isFirstMount.current) {
       isFirstMount.current = false;
       loadBulletins();
@@ -169,14 +169,6 @@ export default function BulletinsListPage() {
     setTrackedBulletins({});
     loadBulletins();
   }, [location.key]);
-
-  useEffect(() => {
-    return () => {
-      if (bulletinsRef.current && bulletinsRef.current.length) {
-        markBulletinsAsRead(bulletinsRef.current, cmsContextRef.current, setCMSContext);
-      }
-    };
-  }, []);
 
   // Intersection observer
   useEffect(() => {


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6876](https://moti-imb.atlassian.net/browse/DBC22-6876)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
**Precondition:** At least 2 Advisories (and/or Bulletins) exist.

1. In CMS, update multiple Advisories and/or Bulletins using **Publish with notifications**.
2. Open the Advisories and/or Bulletins list and confirm multiple items show blue highlight + **Updated** pill, and the header count matches.
3. Open only one detail page, then return to the list.
4. Confirm only the viewed item lost its Updated indicators; other unread items and the header count remain.
5. Repeat for Bulletins.

**Note:** For Bulletins header pill, also see DBC22-6874 if the count was missing entirely.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
