### PR TITLE
DBC22-6880: show list update indicators on first visit

### DIFF
--- a/src/frontend/src/pages/AdvisoriesListPage.js
+++ b/src/frontend/src/pages/AdvisoriesListPage.js
@@ -29,7 +29,6 @@ import PollingComponent from "../Components/shared/PollingComponent";
 import './AdvisoriesListPage.scss';
 
 export default function AdvisoriesListPage() {
-  const isFirstVisitRef = useRef(!sessionStorage.getItem('lastAdvisoriesVisit'));
   document.title = 'DriveBC - Advisories';
 
   // Context
@@ -117,7 +116,7 @@ const loadAdvisories = async () => {
 
   const isDismissed = dismissedHighlightsRef.current.has(String(advisory.id));
 
-  const isUnread = !isFirstVisitRef.current &&
+  const isUnread =
     advisory.last_notified_at &&
     !currentContext.readAdvisories.includes(
       advisory.id.toString() + '-' + advisory.last_notified_at.toString()
@@ -160,14 +159,7 @@ const loadAdvisories = async () => {
 };
 
 useEffect(() => {
-  sessionStorage.setItem(
-    'lastAdvisoriesVisit',
-    new Date().toISOString()
-  );
-}, []);
-
-useEffect(() => {
-  if (!advisories?.length || isFirstVisitRef.current) return;
+  if (!advisories?.length) return;
 
   const initialTracked = advisories.reduce((acc, advisory) => {
     const isDismissed = dismissedHighlightsRef.current.has(String(advisory.id));

--- a/src/frontend/src/pages/BulletinsListPage.js
+++ b/src/frontend/src/pages/BulletinsListPage.js
@@ -28,7 +28,6 @@ import { useLocation } from "react-router-dom";
 import './BulletinsListPage.scss';
 
 export default function BulletinsListPage() {
-  const isFirstVisitRef = useRef(!sessionStorage.getItem('lastBulletinsVisit'));
   document.title = 'DriveBC - Bulletins';
 
   // Context
@@ -49,7 +48,7 @@ export default function BulletinsListPage() {
   const dismissedHighlightsRef = useRef(
     new Set(JSON.parse(sessionStorage.getItem('dismissedBulletinHighlights') || '[]'))
   );
-  
+
 
   // States
   const [showLoader, setShowLoader] = useState(true);
@@ -124,7 +123,7 @@ export default function BulletinsListPage() {
       );
     }
 
-      const isUnread = !isFirstVisitRef.current &&
+      const isUnread =
         bulletin.last_notified_at &&
         !currentContext.readBulletins.includes(
           bulletin.id.toString() + '-' + bulletin.last_notified_at.toString()
@@ -158,7 +157,7 @@ export default function BulletinsListPage() {
 
   useEffect(() => {
     cmsContextRef.current = cmsContext;
-  
+
     if (isFirstMount.current) {
       isFirstMount.current = false;
       loadBulletins();
@@ -221,13 +220,6 @@ export default function BulletinsListPage() {
 useEffect(() => {
   bulletinsRef.current = bulletins;
 }, [bulletins]);
-
-  useEffect(() => {
-    sessionStorage.setItem(
-      'lastBulletinsVisit',
-      new Date().toISOString()
-    );
-  }, []);
 
   const scrollToNextHighlightedHandler = (direction) => {
     const offset = 58 + 48;


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6880](https://moti-imb.atlassian.net/browse/DBC22-6880)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
**Precondition:** An advisory (and optionally bulletin) already exists.

1. In CMS, edit an Advisory or Bulletin and **Publish with notifications**.
2. Open DriveBC in a fresh/incognito session. Confirm the header update pill is visible.
3. Navigate to the Advisories (or Bulletins) list via the header — do **not** refresh.
4. Confirm the updated item(s) show list indicators (blue highlight + **Updated** pill) on first entry.
5. Confirm a hard refresh is no longer required to see which items are updated.

**Note:** Bulletin list indicators may still be masked if DBC22-6874 is not merged (header count missing). Viewing one item clearing all indicators is covered by DBC22-6876.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
