### PR TITLE
DBC22-6239: update delay sidepanel when event becomes current

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -52,7 +52,8 @@ import {
   zoomIn,
   zoomOut,
   fitMap,
-  removeOverlays
+  removeOverlays,
+  setEventStyle
 } from './helpers';
 import { layerNameMap, toggleableLayers } from "./enums";
 import { loadLayer, loadEventsLayers, updateEventsLayers, enableReferencedLayer } from './layers';
@@ -882,10 +883,22 @@ export default function DriveBCMap(props) {
     // Count filtered events to store in routeDetails
     if (filteredEvents) {
       // Toggle features visibility
-      updateEventsLayers(
+      const featuresDict = updateEventsLayers(
         mapContext, filteredEvents, mapLayers, setLoadingLayers, clickedFeature, mapView,
         featureContext, setFeatureContext // DBC22-5106
       );
+
+      // If the open event was recreated (e.g. future→current), point at the new feature
+      const clicked = clickedFeatureRef.current;
+      if (clicked?.get?.('type') === 'event' && featuresDict) {
+        const updatedFeature = featuresDict[clicked.getId()];
+        if (updatedFeature && updatedFeature !== clicked) {
+          updatedFeature.set('clicked', true);
+          setEventStyle(updatedFeature, 'active');
+          setEventStyle(updatedFeature.get('altFeature') || [], 'active');
+          updateClickedFeature(updatedFeature, false);
+        }
+      }
 
       const eventCounts = {
         closures: 0,

--- a/src/frontend/src/Components/map/layers/eventsLayer.js
+++ b/src/frontend/src/Components/map/layers/eventsLayer.js
@@ -198,7 +198,7 @@ export function updateEventsLayers(
   featureContext, setFeatureContext  // Feature context for route details panel
 ) {
   const featuresDict = {};
-  const contextFeaturesDict = featureContext.events || {};
+  const contextFeaturesDict = { ...(featureContext.events || {}) };
 
   const eventsDict = events.reduce((dict, obj) => {
     dict[obj.id] = obj;
@@ -210,25 +210,37 @@ export function updateEventsLayers(
   Object.values(mapLayers.current).forEach((layer) => {
     if (layer.get('classname') !== 'events') { return; }  // skip non-event layers
 
-    // for each feature in a layer, set the style or hide the
-    // feature, depending on whether the event is current
-    for (const feature of layer.getSource().getFeatures()) {
+    const isLineLayer = layer.name.endsWith('Lines');
+    const baseLayerName = isLineLayer ? layer.name.slice(0, -5) : layer.name;
+
+    // Copy before mutating source (category changes remove features)
+    for (const feature of [...layer.getSource().getFeatures()]) {
       const featureId = feature.getId();
       if (featureId in eventsDict) {
+        const event = eventsDict[featureId];
+
+        // Recreate on the correct layer when future→current (etc.)
+        if (event.display_category !== baseLayerName) {
+          layer.getSource().removeFeature(feature);
+          if (!isLineLayer) {
+            delete contextFeaturesDict[featureId];
+          }
+          continue;
+        }
+
         // Update the feature with the new event data
-        feature.setProperties(eventsDict[featureId]);
+        feature.setProperties(event);
         setEventStyle(feature, clickedFeature?.getId() === featureId ? 'active' : 'static');
         processedEvents.add(featureId);  // Track processed events
-        featuresDict[featureId] = feature;
+
+        if (!isLineLayer) {
+          featuresDict[featureId] = feature;
+          contextFeaturesDict[featureId] = feature;
+        }
 
       // Hide the feature if not in filtered data list
       } else {
         feature.setStyle(new Style(null));
-      }
-
-      // Store point features in dict for context
-      if (!(layer.name.endsWith('Lines')) && !(feature.featureId in contextFeaturesDict)) {
-        contextFeaturesDict[featureId] = feature;
       }
     }
   });
@@ -246,7 +258,15 @@ export function updateEventsLayers(
   Object.values(eventsDict).forEach((event) => {
     if (processedEvents.has(event.id)) { return; }
 
+    delete contextFeaturesDict[event.id];
     processEvent(mapContext, event, 'EPSG:3857', vsMap, lineVsMap, null, null, true, contextFeaturesDict);
+  });
+
+  // Include newly created point features (e.g. after category change)
+  Object.entries(contextFeaturesDict).forEach(([featureId, feature]) => {
+    if (featureId in eventsDict) {
+      featuresDict[featureId] = feature;
+    }
   });
 
   // Update feature context with new features

--- a/src/frontend/src/Components/map/panels/EventPanel.js
+++ b/src/frontend/src/Components/map/panels/EventPanel.js
@@ -1,5 +1,9 @@
 // React
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
+
+// Redux
+import { useSelector } from 'react-redux';
+import { memoize } from 'proxy-memoize';
 
 // Navigation
 import { useSearchParams } from 'react-router-dom';
@@ -126,18 +130,32 @@ export default function EventPanel(props) {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const eventData = feature.ol_uid ? feature.getProperties() : feature;
+  const featureProps = feature.ol_uid ? feature.getProperties() : feature;
+
+  // Prefer polled feed data so the panel updates when an event becomes current
+  // (OpenLayers feature properties are mutated in place without a React state change).
+  const { eventsList, filteredEventsList } = useSelector(
+    useCallback(
+      memoize(state => ({
+        eventsList: state.feeds.events.list,
+        filteredEventsList: state.feeds.events.filteredList,
+      })),
+    ),
+  );
+
+  const eventFromFeed = (eventsList || filteredEventsList || []).find(
+    (event) => event.id == featureProps.id
+  );
+  const eventData = eventFromFeed || featureProps;
   const severity = eventData.severity.toLowerCase();
 
   // useEffect hooks
   useEffect(() => {
-    const event = feature.getProperties();
-
     searchParams.set('type', 'event');
-    searchParams.set('display_category', event.display_category);
-    searchParams.set('id', event.id);
+    searchParams.set('display_category', eventData.display_category);
+    searchParams.set('id', eventData.id);
     setSearchParams(searchParams, { replace: true });
-  }, [feature]);
+  }, [feature, eventData.display_category, eventData.id]);
 
   return (
     <div


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6239](https://moti-imb.atlassian.net/browse/DBC22-6239)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Create/publish a delay that will become current soon, open it on the map so the sidepanel shows “future event”.
2. Wait until the event becomes current (map icon updates).
3. Confirm the open sidepanel title/icon/text update to the current event type without refreshing the page.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented

Made with [Cursor](https://cursor.com)