### PR TITLE
DBC22-6513: fix camera list south-to-north highway ordering

### DIFF
--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -520,11 +520,11 @@ def build_route_geometries(coords=hwy_coords):
             points_list = [Point(p) for p in response.json()['route']]
             ls_routes.append(LineString(points_list))
 
-        # DBC22-2456
+        # DBC22-2456 / DBC22-6513: reverse so camera order is south→north (and west→east)
         highways_to_reverse = [
-            '2', '3B', '9', '11', '13', '15', '17A', '23',
+            '2', '3B', '9', '11', '13', '15', '17A', '19', '19A', '23',
             '27', '29', '31', '33', '35', '37', '43', '91A',
-            '93', '95', '97', '97C'
+            '93', '95', '97', '97C', '99A'
         ]
 
         if key in highways_to_reverse:

--- a/src/frontend/src/pages/CamerasListPage.js
+++ b/src/frontend/src/pages/CamerasListPage.js
@@ -222,7 +222,8 @@ export default function CamerasListPage() {
       } else {
         const highwayCompare = collator.compare(a.highway_display, b.highway_display);
         if (highwayCompare == 0) {
-          return collator.compare(a.route_order, b.route_order);
+          // Numeric compare — Collator stringifies null/undefined unpredictably
+          return (a.route_order ?? Number.MAX_SAFE_INTEGER) - (b.route_order ?? Number.MAX_SAFE_INTEGER);
         }
 
         return highwayCompare;

--- a/src/frontend/src/pages/SavedCamerasPage.js
+++ b/src/frontend/src/pages/SavedCamerasPage.js
@@ -116,7 +116,8 @@ export default function SavedCamerasPage() {
         // Sort by highway first, then default highway/route order
         const highwayCompare = collator.compare(a.highway_display, b.highway_display);
         if (highwayCompare == 0) {
-          return collator.compare(a.route_order, b.route_order);
+          // Numeric compare — Collator stringifies null/undefined unpredictably
+          return (a.route_order ?? Number.MAX_SAFE_INTEGER) - (b.route_order ?? Number.MAX_SAFE_INTEGER);
         }
 
         return highwayCompare;


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6513](https://moti-imb.atlassian.net/browse/DBC22-6513)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. After deploy, rebuild camera route geometries and orders:
   - `python manage.py build_route_geometries` (or equivalent task)
   - `python manage.py add_camera_orders`
2. Open the Camera list page.
3. Check Hwy 19 (and 19A) groupings: cameras should order south → north.
4. Check Hwy 1 still orders west → east and Hwy 97 south → north.
5. Confirm Saved cameras list uses the same within-highway ordering.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented

Made with [Cursor](https://cursor.com)