### PR TITLE
DBC22-5419: fix camera detail mini-map layer defaults

### DIFF
--- a/src/frontend/src/Components/map/Map.js
+++ b/src/frontend/src/Components/map/Map.js
@@ -520,9 +520,10 @@ export default function DriveBCMap(props) {
     // Enable referenced layer
     enableReferencedLayer(referenceData, mapContext);
 
-    // Enable highway cams layer if in cam detail
+    // Enable highway cams and ferries layers if in cam detail (locked on)
     if (isCamDetail) {
       mapContext.visible_layers['highwayCams'] = true;
+      mapContext.visible_layers['inlandFerries'] = true;
     }
 
     const tileSource = new VectorTileSource({

--- a/src/frontend/src/Components/map/filter/MapFilters.js
+++ b/src/frontend/src/Components/map/filter/MapFilters.js
@@ -63,7 +63,7 @@ export default function MapFilters(props) {
   const [roadConditions, setRoadConditions] = useState(mapContext.visible_layers.roadConditions);
   const [chainUps, setChainUps] = useState(mapContext.visible_layers.chainUps);
   const [highwayCams, setHighwayCams] = useState(isCamDetail ? true : mapContext.visible_layers.highwayCams);
-  const [inlandFerries, setInlandFerries] = useState(isCamDetail ? true : mapContext.visible_layers.highwayCams);
+  const [inlandFerries, setInlandFerries] = useState(isCamDetail ? true : mapContext.visible_layers.inlandFerries);
   const [weather, setWeather] = useState(mapContext.visible_layers.weather);
   const [restStops, setRestStops] = useState(mapContext.visible_layers.restStops);
   const [largeRestStops, setLargeRestStops] = useState(mapContext.visible_layers.largeRestStops);
@@ -71,6 +71,18 @@ export default function MapFilters(props) {
   const [dms, setDms] = useState(mapContext.visible_layers.dms);
 
   // Effects
+  // Camera detail: ensure locked-on layers are visible once created
+  useEffect(() => {
+    if (!isCamDetail || !mapLayers?.current) return;
+
+    if (mapLayers.current.highwayCams) {
+      mapLayers.current.highwayCams.setVisible(true);
+    }
+    if (mapLayers.current.inlandFerries) {
+      mapLayers.current.inlandFerries.setVisible(true);
+    }
+  }, [isCamDetail, mapLayers, loadingLayers?.ferries, loadingLayers?.cameras]);
+
   useEffect(() => {
     if (isInitialLoad.current) {
       isInitialLoad.current = false;
@@ -393,7 +405,7 @@ export default function MapFilters(props) {
                   name="ferries"
                   id="filter--inland-ferries"
                   onChange={e => filterHandler('inlandFerries', e)}
-                  defaultChecked={mapContext.visible_layers.inlandFerries}
+                  defaultChecked={isCamDetail || mapContext.visible_layers.inlandFerries}
                   disabled={isCamDetail || disableFeatures} />
 
                 <label className="filter-item__button" htmlFor="filter--inland-ferries">


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-5419](https://moti-imb.atlassian.net/browse/DBC22-5419)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Open a camera details page.
2. Open Map layers on the mini-map.
3. Confirm Ferries is locked on and displayed.
4. Confirm Weather, Wildfires, and Rest stops (commercial + non) are toggleable and respect main-map filter state.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
