### PR TITLE
DBC22-5392: prevent unfiltered map icons flash during route polling

### DIFF
--- a/src/frontend/src/Components/map/MapWrapper.js
+++ b/src/frontend/src/Components/map/MapWrapper.js
@@ -124,12 +124,18 @@ export default function MapWrapper(props) {
   useEffect(() => {
     selectedRouteRef.current = selectedRoute;
 
+    // Recreate worker on route change so in-flight messages for the previous route are dropped
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+
     loadData();
 
-    // Cleanup function to terminate the worker when the component unmounts
     return () => {
       if (workerRef.current) {
         workerRef.current.terminate();
+        workerRef.current = null;
       }
     };
   }, [selectedRoute]);
@@ -179,17 +185,23 @@ export default function MapWrapper(props) {
     dmsRef.current = dms;
   }, [dms]);
 
-  const resetWorker = () => {
-    // Terminate the current worker if it exists
+  const ensureWorker = () => {
+    // Keep a single worker across polls — terminating on every reload drops
+    // in-flight filter results and can briefly show unfiltered icons (DBC22-5392).
     if (workerRef.current) {
-      workerRef.current.terminate();
+      return;
     }
 
     workerRef.current = new Worker(new URL('./filterRouteWorker.js', import.meta.url));
 
-    // Set up event listener for messages from the worker
     workerRef.current.onmessage = function (event) {
-      const { data, filteredData, action } = event.data;
+      const { data, filteredData, action, route } = event.data;
+
+      // Ignore stale unfiltered results when a route is still selected
+      const routeSelected = selectedRouteRef.current && selectedRouteRef.current.routeFound;
+      if (routeSelected && !route) {
+        return;
+      }
 
       dispatch(
         slices[action]({
@@ -203,7 +215,7 @@ export default function MapWrapper(props) {
 
   // Function to load all data
   const loadData = () => {
-    resetWorker();
+    ensureWorker();
 
     const routeData = selectedRouteRef.current && selectedRouteRef.current.routeFound ? selectedRouteRef.current : null;
 

--- a/src/frontend/src/Components/shared/PollingComponent.js
+++ b/src/frontend/src/Components/shared/PollingComponent.js
@@ -1,33 +1,37 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export default function PollingComponent(props) {
   /* Setup */
   // Props
   const { interval, runnable, runImmediately=false } = props;
 
+  // Always call the latest runnable (avoid stale closure from mount-only effect)
+  const runnableRef = useRef(runnable);
+  runnableRef.current = runnable;
+
   // Effects
   useEffect(() => {
     let intervalId;
+
+    const tick = () => {
+      runnableRef.current();
+    };
 
     const handleVisibilityChange = () => {
       if (document.hidden) {
         clearInterval(intervalId);
       } else {
-        intervalId = setInterval(() => {
-          runnable();
-        }, interval);
+        intervalId = setInterval(tick, interval);
       }
     };
 
     // Set up initial timeout to delay the first execution
     const timeoutId = setTimeout(() => {
-      intervalId = setInterval(() => {
-        runnable();
-      }, interval);
+      intervalId = setInterval(tick, interval);
     }, interval);
 
     if (runImmediately) {
-      setTimeout(runnable, 0);
+      setTimeout(tick, 0);
     }
 
     // Add visibility change event listener
@@ -39,7 +43,7 @@ export default function PollingComponent(props) {
       clearInterval(intervalId);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, []);
+  }, [interval]);
 
   /* Rendering */
   // Main component


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-5392](https://moti-imb.atlassian.net/browse/DBC22-5392)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Select a route on the map.
2. Wait for automatic polling (~30s) or leave the tab and return.
3. Confirm map icons do not briefly flash to the unfiltered (province-wide) set.
4. Related camera ordering: see DBC22-5976.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
