### PR TITLE
DBC22-5976: stabilise camera route filter order and polling updates

### DIFF
--- a/src/frontend/src/Components/map/MapWrapper.js
+++ b/src/frontend/src/Components/map/MapWrapper.js
@@ -124,12 +124,18 @@ export default function MapWrapper(props) {
   useEffect(() => {
     selectedRouteRef.current = selectedRoute;
 
+    // Recreate worker on route change so in-flight messages for the previous route are dropped
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+
     loadData();
 
-    // Cleanup function to terminate the worker when the component unmounts
     return () => {
       if (workerRef.current) {
         workerRef.current.terminate();
+        workerRef.current = null;
       }
     };
   }, [selectedRoute]);
@@ -179,17 +185,23 @@ export default function MapWrapper(props) {
     dmsRef.current = dms;
   }, [dms]);
 
-  const resetWorker = () => {
-    // Terminate the current worker if it exists
+  const ensureWorker = () => {
+    // Keep a single worker across polls — terminating on every reload drops
+    // in-flight filter results and can briefly show unfiltered icons (DBC22-5392).
     if (workerRef.current) {
-      workerRef.current.terminate();
+      return;
     }
 
     workerRef.current = new Worker(new URL('./filterRouteWorker.js', import.meta.url));
 
-    // Set up event listener for messages from the worker
     workerRef.current.onmessage = function (event) {
-      const { data, filteredData, action } = event.data;
+      const { data, filteredData, action, route } = event.data;
+
+      // Ignore stale unfiltered results when a route is still selected
+      const routeSelected = selectedRouteRef.current && selectedRouteRef.current.routeFound;
+      if (routeSelected && !route) {
+        return;
+      }
 
       dispatch(
         slices[action]({
@@ -203,7 +215,7 @@ export default function MapWrapper(props) {
 
   // Function to load all data
   const loadData = () => {
-    resetWorker();
+    ensureWorker();
 
     const routeData = selectedRouteRef.current && selectedRouteRef.current.routeFound ? selectedRouteRef.current : null;
 

--- a/src/frontend/src/Components/map/filterRouteWorker.js
+++ b/src/frontend/src/Components/map/filterRouteWorker.js
@@ -11,7 +11,9 @@ self.onmessage = (event) => {
         filteredData = filterAdvisoryByRoute(data, route);
         break;
       case 'updateCameras':
-        filteredData = filterByRoute(data, route, 50, false);
+        // populateProjection=true so camera order along the route is stable
+        // (DBC22-5976: intermittent wrong first camera / filter flash)
+        filteredData = filterByRoute(data, route, 50, true);
         break;
       case 'updateEvents':
         filteredData = filterByRoute(data, route, null, true);


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-5976](https://moti-imb.atlassian.net/browse/DBC22-5976)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** No

#### 🧪 How to Test (if required)
1. Select a route with cameras (e.g. Kamloops to Victoria).
2. Watch the camera list/map across a data refresh/poll.
3. Confirm cameras outside the route do not appear, and the first camera along the route stays correct.
4. Related polling flash: see DBC22-5392.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
