### PR TITLE
DBC22-6899: expand isInBc for neighbouring regions and US

### DIFF
--- a/src/frontend/src/Components/routing/NoRouteFound.js
+++ b/src/frontend/src/Components/routing/NoRouteFound.js
@@ -13,12 +13,21 @@ import './NoRouteFound.scss';
 export default function NoRouteFound(props) {
   const { searchedRoutes, searchLocationFrom, searchLocationTo } = props;
 
+  // BC plus neighbouring provinces/territories and US border locations we list as routable
+  const isInBcRegion = (label) => (
+    label.includes(', BC') ||
+    label.includes(', AB') ||
+    label.includes(', YT') ||
+    label.includes(', NT') ||
+    label.includes(', US')
+  );
+
   const isInBc = (searchLocationFrom, searchLocationTo) => {
     return searchLocationFrom[0] && searchLocationTo[0] && (
-      (searchLocationFrom[0].label.includes(', BC') && searchLocationTo[0].label.includes(', BC')) ||
+      (isInBcRegion(searchLocationFrom[0].label) && isInBcRegion(searchLocationTo[0].label)) ||
       (searchLocationFrom[0].label.includes('Current location'))
     );
-}
+  }
 
   // Rendering
   return (


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** [DBC22-6899](https://moti-imb.atlassian.net/browse/DBC22-6899)

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > No

#### 🧪 How to Test (if required)
1. Open the map and enter **Seattle, US (via Highway 99)** as the start and **Lillooet, BC** as the destination (or another BC location).
2. If no route is returned, confirm the message is **"No valid route between these two points."** — not **"Routes outside of BC are not possible at the moment."**
3. Repeat with a neighbouring-province style label if available (e.g. `, AB` / `, YT`) paired with a BC location; same expected messaging when no route exists.
4. Confirm a clearly out-of-region pair (e.g. Ontario) still shows **"Routes outside of BC are not possible at the moment."**
5. Confirm **Seattle, US (via Highway 15)** to a BC location still routes successfully when the service returns a route.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
