### PR TITLE
DBC22-6145: not showing all 30km away stations for cameras

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "DriveBC.ca",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -550,6 +550,10 @@ def update_camera_weather_station(camera, weather_class):
             elevation__lte=camera.elevation + 300,
             elevation__gte=camera.elevation - 300,
         )
+    elif weather_class == RegionalWeather or weather_class == HighElevationForecast:
+        stations_qs = stations_qs.filter(
+            distance__lte=D(km=30),
+        )
 
     closest_station = stations_qs.order_by('distance').first()
 

--- a/src/backend/apps/webcam/tasks.py
+++ b/src/backend/apps/webcam/tasks.py
@@ -582,6 +582,10 @@ def update_camera_weather_station(camera, weather_class):
             elevation__lte=camera.elevation + 300,
             elevation__gte=camera.elevation - 300,
         )
+    elif weather_class == RegionalWeather or weather_class == HighElevationForecast:
+        stations_qs = stations_qs.filter(
+            distance__lte=D(km=30),
+        )
 
     closest_station = stations_qs.order_by('distance').first()
 

--- a/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.js
+++ b/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.js
@@ -54,10 +54,13 @@ export default function NearbyWeathers(props) {
   const defaultActiveTab = weatherTabs.length ? weatherTabs[0].key : null;
   const [activeTab, setActiveTab] = useState(defaultActiveTab);
 
+  const hasWeather = localWeather || regionalWeather || hef;
+
   // Effects
   // find regional weather and set state
   useEffect(() => {
     if (!regionalWeatherList || !camera.regional_weather_station) {
+      setRegionalWeather(null);
       return;
     }
 
@@ -69,6 +72,7 @@ export default function NearbyWeathers(props) {
   // find local weather and set state
   useEffect(() => {
     if (!currentWeatherList || !camera.local_weather_station) {
+      setLocalWeather(null);
       return;
     }
 
@@ -80,6 +84,7 @@ export default function NearbyWeathers(props) {
   // find hef and set state
   useEffect(() => {
     if (!hefList || !camera.hev_station) {
+      setHef(null);
       return;
     }
 
@@ -102,7 +107,7 @@ export default function NearbyWeathers(props) {
 
   /* Rendering */
   // Loading state
-  if (!regionalWeather && !localWeather && !hef) {
+  if ((regionalWeather || localWeather || hef) && (!regionalWeather && !localWeather && !hef)) {
     return (
       <div>
         <Skeleton height={48}/>
@@ -139,18 +144,30 @@ export default function NearbyWeathers(props) {
             })}
           </div>
         </div>
+        <div>
+        {!hasWeather ? (
+          <div className="weather-empty">
+            <h3>No nearby weather available</h3>
+            <p>
+              Unfortunately there is no nearby weather data available for this camera.
+            </p>
+          </div>
+        ) : (
+          <>
+            {activeTab === 'Roadside' && localWeather && (
+              <NearbyLocalWeather weather={localWeather} />
+            )}
 
-        { activeTab === 'Roadside' && localWeather &&
-          <NearbyLocalWeather weather={localWeather} />
-        }
+            {activeTab === 'Regional' && regionalWeather && (
+              <NearbyRegionalWeather weather={regionalWeather} />
+            )}
 
-        { activeTab === 'Regional' && regionalWeather &&
-          <NearbyRegionalWeather weather={regionalWeather} />
-        }
-
-        { activeTab === 'High elevation' && hef &&
-          <NearbyHevWeather weather={hef} />
-        }
+            {activeTab === 'High elevation' && hef && (
+              <NearbyHevWeather weather={hef} />
+            )}
+          </>
+        )}
+        </div>
       </div>
     </React.Fragment>
   );

--- a/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.jsx
+++ b/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.jsx
@@ -54,10 +54,13 @@ export default function NearbyWeathers(props) {
   const defaultActiveTab = weatherTabs.length ? weatherTabs[0].key : null;
   const [activeTab, setActiveTab] = useState(defaultActiveTab);
 
+  const hasWeather = localWeather || regionalWeather || hef;
+
   // Effects
   // find regional weather and set state
   useEffect(() => {
     if (!regionalWeatherList || !camera.regional_weather_station) {
+      setRegionalWeather(null);
       return;
     }
 
@@ -69,6 +72,7 @@ export default function NearbyWeathers(props) {
   // find local weather and set state
   useEffect(() => {
     if (!currentWeatherList || !camera.local_weather_station) {
+      setLocalWeather(null);
       return;
     }
 
@@ -80,6 +84,7 @@ export default function NearbyWeathers(props) {
   // find hef and set state
   useEffect(() => {
     if (!hefList || !camera.hev_station) {
+      setHef(null);
       return;
     }
 
@@ -102,7 +107,7 @@ export default function NearbyWeathers(props) {
 
   /* Rendering */
   // Loading state
-  if (!regionalWeather && !localWeather && !hef) {
+  if ((regionalWeather || localWeather || hef) && (!regionalWeather && !localWeather && !hef)) {
     return (
       <div>
         <Skeleton height={48}/>
@@ -139,18 +144,30 @@ export default function NearbyWeathers(props) {
             })}
           </div>
         </div>
+        <div>
+        {!hasWeather ? (
+          <div className="weather-empty">
+            <h3>No nearby weather available</h3>
+            <p>
+              Unfortunately there is no nearby weather data available for this camera.
+            </p>
+          </div>
+        ) : (
+          <>
+            {activeTab === 'Roadside' && localWeather && (
+              <NearbyLocalWeather weather={localWeather} />
+            )}
 
-        { activeTab === 'Roadside' && localWeather &&
-          <NearbyLocalWeather weather={localWeather} />
-        }
+            {activeTab === 'Regional' && regionalWeather && (
+              <NearbyRegionalWeather weather={regionalWeather} />
+            )}
 
-        { activeTab === 'Regional' && regionalWeather &&
-          <NearbyRegionalWeather weather={regionalWeather} />
-        }
-
-        { activeTab === 'High elevation' && hef &&
-          <NearbyHevWeather weather={hef} />
-        }
+            {activeTab === 'High elevation' && hef && (
+              <NearbyHevWeather weather={hef} />
+            )}
+          </>
+        )}
+        </div>
       </div>
     </React.Fragment>
   );

--- a/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.scss
+++ b/src/frontend/src/Components/cameras/nearbyweathers/NearbyWeathers.scss
@@ -316,3 +316,10 @@
     }
   }
 }
+
+.weather-empty {
+  h3 {
+    font-size: 16px;
+    font-weight: 700;
+  }
+}


### PR DESCRIPTION
DBC22-6145: fixed the issue that showing all 30km away stations for maceras

### 📝 Submitter

#### 🔗 JIRA Ticket
- [ ] **Ticket Link:** https://moti-imb.atlassian.net/browse/DBC22-6145

---

#### ✅ Quality Assurance & Requirements
- [ ] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [ ] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [ ] **New Env Variables:** Does this PR require new environment variables? (Yes/No)
  > *If yes, please list them here and ensure they are added to secret manager, the `.env.example`.* and the Vault by an STA. 

#### 🧪 How to Test (if required)
1. Deploy to dev.
2. Go to camera details page, verify if the closest is more than 30km in straight-line distance from the camera, it will not be displayed.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented