### PR TITLE
DBC22-7295: Hide Publish minor update until first notify

### DIFF
--- a/src/backend/apps/cms/views.py
+++ b/src/backend/apps/cms/views.py
@@ -2,23 +2,21 @@ from apps.cms.models import Advisory, Bulletin, EmergencyAlert, EmergencyAlertDe
 from apps.cms.serializers import (
     AdvisorySerializer,
     BulletinSerializer,
+    EmergencyAlertDetailSerializer,
     EmergencyAlertSerializer,
     EmergencyAlertTestSerializer,
-    EmergencyAlertDetailSerializer,
 )
 from apps.shared.enums import CacheKey, CacheTimeout
 from apps.shared.views import CachedListModelMixin
 from django.conf import settings
+from django.contrib import messages
 from django.core.mail import EmailMultiAlternatives
-from django.http import HttpResponseRedirect
-from django.shortcuts import render, reverse
+from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import redirect, render, reverse
 from django.template.loader import render_to_string
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import viewsets
-from django.contrib import messages
-from django.shortcuts import redirect
 from wagtail.models import Page
-from django.http import Http404
 
 
 class CMSViewSet(viewsets.ReadOnlyModelViewSet):
@@ -99,10 +97,12 @@ class EmergencyAlertAPI(CachedListModelMixin, EmergencyAlertTestAPI):
     cache_key = CacheKey.EMERGENCY_ALERT_LIST
     cache_timeout = CacheTimeout.EMERGENCY_ALERT_LIST
 
+
 class EmergencyAlertDetailTestAPI(CMSViewSet):
     queryset = EmergencyAlertDetail.objects.all()
     serializer_class = EmergencyAlertDetailSerializer
     lookup_field = 'slug'
+
 
 class EmergencyAlertDetailAPI(CachedListModelMixin, EmergencyAlertDetailTestAPI):
     queryset = EmergencyAlertDetail.objects.all()
@@ -112,6 +112,7 @@ class EmergencyAlertDetailAPI(CachedListModelMixin, EmergencyAlertDetailTestAPI)
 
     def get_queryset(self):
         return EmergencyAlertDetail.objects.filter(live=True)  # live only
+
 
 @csrf_exempt
 def access_requested(request):
@@ -153,14 +154,23 @@ def access_denied_idir(request):
 
 
 def publish_minor_update(request, page_id):
+    try:
+        page_id = int(page_id)
+    except (TypeError, ValueError):
+        raise Http404()
+
     if request.method != "POST":
-        try:
-            page_id = int(page_id)
-        except (TypeError, ValueError):
-            raise Http404()
         return redirect(f"/drivebc-cms/pages/{page_id}/edit/")
 
     page = Page.objects.get(pk=page_id).specific
+
+    if not isinstance(page, (Advisory, Bulletin)) or page.last_notified_at is None:
+        messages.error(
+            request,
+            'Publish minor update is only available after publishing with notifications at least once.',
+        )
+        return redirect(f"/drivebc-cms/pages/{page_id}/edit/")
+
     latest_revision = page.get_latest_revision()
 
     if latest_revision:
@@ -180,8 +190,4 @@ def publish_minor_update(request, page_id):
         )
 
     messages.success(request, f'"{page.title}" published as a minor update.')
-    try:
-        page_id = int(page_id)
-    except (TypeError, ValueError):
-        raise Http404()
     return redirect(f"/drivebc-cms/pages/{page_id}/edit/")

--- a/src/backend/apps/cms/wagtail_hooks.py
+++ b/src/backend/apps/cms/wagtail_hooks.py
@@ -1,27 +1,28 @@
 import logging
 import os
 
-from apps.cms.models import EmergencyAlert, EmergencyAlertDetail
+from apps.cms.models import EmergencyAlert
 from apps.cms.tasks import send_advisory_notifications
 from django.contrib.auth.models import Permission
+from django.shortcuts import redirect
 from django.templatetags.static import static
-from django.urls import path
+from django.urls import path, reverse
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from wagtail import hooks
+from wagtail.admin.action_menu import ActionMenuItem
 from wagtail.admin.rich_text.editors.draftail.features import ControlFeature
 from wagtail.admin.ui.components import Component
 from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
 
-from .models import Advisory, Bulletin, SubPage, get_or_create_advisory_index, get_or_create_bulletin_index
+from .models import (
+    Advisory,
+    Bulletin,
+    SubPage,
+    get_or_create_advisory_index,
+    get_or_create_bulletin_index,
+)
 from .views import access_requested, publish_minor_update
-
-# from wagtail.admin.ui.components import ActionMenuItem
-from wagtail.admin.action_menu import ActionMenuItem
-from django.urls import reverse
-from django.utils.html import format_html
-
-from django.utils.safestring import mark_safe
-from django.shortcuts import redirect
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 @hooks.register("after_publish_page")
 def post_edit_hook(request, page):
     from django.utils import timezone
-    
+
     if page.specific_class == Advisory:
         try:
             Advisory.objects.filter(pk=page.pk).update(last_notified_at=timezone.now())
@@ -142,18 +143,12 @@ def add_access_request_panel(request, panels):
         panels.append(RequestAccessPanel())
 
 
-@hooks.register('register_admin_urls')
-def add_access_requested_url():
-    return [
-        path('access-requested', access_requested, name='cms-access-requested'),
-    ]
-
-
 @hooks.register('after_publish_page')
 def update_parent_page(request, page):
     ''' When saving a subpage, create a new revision for the parent page '''
     if page.specific_class == SubPage:
         page.get_parent().specific.save_revision().publish()
+
 
 class CopyPreviewURLMenuItem(ActionMenuItem):
     label = "Copy Preview URL"
@@ -214,11 +209,31 @@ class CopyPreviewURLMenuItem(ActionMenuItem):
             preview_url,
         )
 
+
 class PublishMinorUpdateMenuItem(ActionMenuItem):
     label = "Publish minor update"
     name = "publish-minor-update"
     icon_name = "upload"
     order = 15
+
+    def is_shown(self, context):
+        if not super().is_shown(context):
+            return False
+
+        page = None
+        if isinstance(context, dict):
+            inner = context.get("context", context)
+            page = inner.get("page") if isinstance(inner, dict) else None
+
+        if page is None:
+            return False
+
+        specific = page.specific
+        if not isinstance(specific, (Advisory, Bulletin)):
+            return False
+
+        # Only after at least one "Publish with notifications"
+        return specific.last_notified_at is not None
 
     def render_html(self, parent_context):
         context = parent_context.get("context", parent_context)
@@ -265,22 +280,24 @@ def register_copy_preview_button():
     """
     return CopyPreviewURLMenuItem(order=100)
 
+
 @hooks.register("insert_global_admin_js")
 def add_custom_emergency_alert_js():
-    return mark_safe("""
+    return mark_safe(  # nosec B308
+        """
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             var path = window.location.pathname;
             if (path.includes('/drivebc-cms/') &&  !path.includes('/advisory/') && !path.includes('/bulletin/')) {
                 fetch('/api/cms/emergency-alert/')
-                        .then(function(response) { 
-                            return response.json(); 
+                        .then(function(response) {
+                            return response.json();
                         })
                         .then(function(data) {
                             if (data && data.length > 0) {
                                 var errorLi = document.querySelector('li.error');
                                 if (errorLi) {
-                                    errorLi.innerHTML = 
+                                    errorLi.innerHTML =
                                         '<svg class="icon icon-warning messages-icon" aria-hidden="true">' +
                                         '<use href="#icon-warning"></use>' +
                                         '</svg>' +
@@ -293,9 +310,10 @@ def add_custom_emergency_alert_js():
                             console.error('Error checking Emergency Alert:', error);
                         });
             }
-        });              
+        });
     </script>
     """)
+
 
 @hooks.register("before_create_page")
 def ensure_advisory_parent(request, parent_page, page_class, **kwargs):
@@ -326,15 +344,18 @@ def ensure_bulletin_parent(request, parent_page, page_class, **kwargs):
 
     return redirect(f"/drivebc-cms/pages/add/cms/bulletin/{index.pk}/")
 
+
 @hooks.register("after_create_page")
 def move_new_advisory_to_top(request, page):
     if page.specific_class == Advisory:
         parent = page.get_parent()
         page.move(parent, pos="first-child")
 
+
 @hooks.register("register_page_action_menu_item")
 def register_publish_minor_update():
     return PublishMinorUpdateMenuItem(order=25)
+
 
 @hooks.register("construct_page_action_menu")
 def customize_page_action_menu(menu_items, request, context):


### PR DESCRIPTION
### 📝 Submitter

#### 🔗 JIRA Ticket
- [x] **Ticket Link:** [DBC22-7295](https://moti-imb.atlassian.net/browse/DBC22-7295)

---

#### ✅ Quality Assurance & Requirements
- [x] **Requirements Met:** I have confirmed that all acceptance criteria from the JIRA ticket are fulfilled.
- [ ] **Tested desktop** in local or dev envs 
- [ ] **Tested mobile** in local or dev envs 
- [x] **Ran unit tests** locally
- [ ] **SonarCloud:** I have verified that the SonarCloud analysis is clean/passing for this branch.

#### ⚙️ Configuration & Environment
- [x] **New Env Variables:** Does this PR require new environment variables? (No)

#### 🧪 How to Test (if required)
1. In CMS, create a new Advisory or Bulletin and save as draft.
2. Open the Save draft menu — confirm **Publish minor update** is not shown (only **Publish with notifications**).
3. Publish with notifications, then edit again — confirm **Publish minor update** is now available.
4. Optionally POST to `/drivebc-cms/publish-minor-update/<id>/` for a never-notified draft and confirm it is rejected with an error message.

---

### 🔍 Reviewer Checklist
- [ ] Reviewed code for logic and cleanliness
- [ ] Re-tested desktop/mobile in local or dev envs
- [ ] Verified no new console warnings/errors
- [ ] Confirmed that any new env variables are understood/documented
